### PR TITLE
Filter 4K/HDR/Dolby Vision sources on Apple TV HD

### DIFF
--- a/tvosApp/NuvioTV.xcodeproj/project.pbxproj
+++ b/tvosApp/NuvioTV.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		AE10B004 /* PlaybackEngineState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F004 /* PlaybackEngineState.swift */; };
 		AE10B005 /* PlaybackEngineCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F005 /* PlaybackEngineCapabilities.swift */; };
 		AE10B006 /* PlaybackBackendPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F006 /* PlaybackBackendPolicy.swift */; };
+		AE10B00C /* AppleTVCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F00C /* AppleTVCapability.swift */; };
+		AE10B00D /* AppleTVCapabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F00D /* AppleTVCapabilityTests.swift */; };
 		AE10B007 /* AetherPlaybackController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F007 /* AetherPlaybackController.swift */; };
 		AE10B008 /* PlaybackSessionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F008 /* PlaybackSessionCoordinator.swift */; };
 		AE10B009 /* MPVPlaybackController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F009 /* MPVPlaybackController.swift */; };
@@ -138,12 +140,14 @@
 
 /* Begin PBXFileReference section */
 		AE10F00B /* PlaybackBackendPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackBackendPolicyTests.swift; sourceTree = "<group>"; };
+		AE10F00D /* AppleTVCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleTVCapabilityTests.swift; sourceTree = "<group>"; };
 		AE10F001 /* PlaybackTrackInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/PlaybackTrackInfo.swift; sourceTree = "<group>"; };
 		AE10F002 /* PlaybackCacheSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/PlaybackCacheSettings.swift; sourceTree = "<group>"; };
 		AE10F003 /* PlaybackLoadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/PlaybackLoadRequest.swift; sourceTree = "<group>"; };
 		AE10F004 /* PlaybackEngineState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/PlaybackEngineState.swift; sourceTree = "<group>"; };
 		AE10F005 /* PlaybackEngineCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/PlaybackEngineCapabilities.swift; sourceTree = "<group>"; };
 		AE10F006 /* PlaybackBackendPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/PlaybackBackendPolicy.swift; sourceTree = "<group>"; };
+		AE10F00C /* AppleTVCapability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/AppleTVCapability.swift; sourceTree = "<group>"; };
 		AE10F007 /* AetherPlaybackController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/AetherPlaybackController.swift; sourceTree = "<group>"; };
 		AE10F008 /* PlaybackSessionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/PlaybackSessionCoordinator.swift; sourceTree = "<group>"; };
 		AE10F009 /* MPVPlaybackController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/MPVPlaybackController.swift; sourceTree = "<group>"; };
@@ -330,6 +334,7 @@ C0D300140000000000000014 /* PlayerView.swift */,
 				AE10F004 /* PlaybackEngineState.swift */,
 				AE10F005 /* PlaybackEngineCapabilities.swift */,
 				AE10F006 /* PlaybackBackendPolicy.swift */,
+				AE10F00C /* AppleTVCapability.swift */,
 				AE10F007 /* AetherPlaybackController.swift */,
 				AE10F008 /* PlaybackSessionCoordinator.swift */,
 				AE10F009 /* MPVPlaybackController.swift */,
@@ -444,6 +449,7 @@ C0D300140000000000000014 /* PlayerView.swift */,
 			isa = PBXGroup;
 			children = (
 				AE10F00B /* PlaybackBackendPolicyTests.swift */,
+				AE10F00D /* AppleTVCapabilityTests.swift */,
 				T0D300E200000000000000E2 /* StreamsDiscoveryTests.swift */,
 				T0D300E3 /* StreamQualityTagsTests.swift */,
 			);
@@ -654,6 +660,7 @@ C0D300140000000000000014 /* PlayerView.swift */,
 				AE10B004 /* PlaybackEngineState.swift in Sources */,
 				AE10B005 /* PlaybackEngineCapabilities.swift in Sources */,
 				AE10B006 /* PlaybackBackendPolicy.swift in Sources */,
+				AE10B00C /* AppleTVCapability.swift in Sources */,
 				AE10B007 /* AetherPlaybackController.swift in Sources */,
 				AE10B008 /* PlaybackSessionCoordinator.swift in Sources */,
 				AE10B009 /* MPVPlaybackController.swift in Sources */,
@@ -709,6 +716,7 @@ C0D300140000000000000014 /* PlayerView.swift */,
 			buildActionMask = 2147483647;
 			files = (
 				AE10B00B /* PlaybackBackendPolicyTests.swift in Sources */,
+				AE10B00D /* AppleTVCapabilityTests.swift in Sources */,
 				T0D310E200000000000000E2 /* StreamsDiscoveryTests.swift in Sources */,
 				T0D310E3 /* StreamQualityTagsTests.swift in Sources */,
 			);

--- a/tvosApp/NuvioTV/Sources/Core/Player/AppleTVCapability.swift
+++ b/tvosApp/NuvioTV/Sources/Core/Player/AppleTVCapability.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// The real playback ceiling for the Apple TV model this process is running
+/// on, used to keep `SmartPlaybackSelector` (see `DetailsScreen.swift`) from
+/// auto-picking — or even offering — a source the hardware cannot actually
+/// decode.
+///
+/// ## Why this exists
+///
+/// Apple TV HD (`AppleTV5,3`, A8 SoC, 2015) has no hardware HEVC decoder at
+/// all — Apple's HEVC media engine shipped starting with A9 — and its video
+/// output is capped at 1080p SDR. When it's handed a 4K and/or Dolby
+/// Vision/HDR source, AetherEngine falls back to software-decoding it, which
+/// saturates the CPU. Verified on physical Apple TV HD hardware: this
+/// produces visibly choppy video *and* completely silent audio (the audio
+/// decode thread starves rather than the video merely dropping frames), for
+/// the entire runtime of playback — not an intermittent glitch.
+///
+/// Every other current Apple TV model (`AppleTV6,2`/`11,1`/`14,1`, the three
+/// Apple TV 4K generations) has hardware HEVC and Dolby Vision/HDR support
+/// and keeps an unrestricted ceiling here — this type changes nothing on
+/// those devices.
+///
+/// ## Extending this for another product/device family
+///
+/// This is intentionally a plain data table keyed by `hw.machine`
+/// (`"AppleTV5,3"`, not the marketing name), not per-device `#if` branches:
+/// adding support for a new box, or reusing this pattern for a different
+/// product line's hardware tiers, is a matter of adding one more table entry
+/// with that model's real decode ceiling — everything else (identifier
+/// lookup, the `isPlayable` gate, the unrestricted-by-default fallback for
+/// hardware this table doesn't recognize yet) stays the same.
+struct AppleTVCapability: Equatable {
+    let maxResolution: Int
+    let supportsHDR: Bool
+    let supportsDolbyVision: Bool
+    let supportsHEVCHardwareDecode: Bool
+    let supportsAV1HardwareDecode: Bool
+
+    /// No known Apple TV hardware has an AV1 decode block yet, hence `false`
+    /// on every entry below — kept as an explicit field (rather than baked
+    /// into `isPlayable`) so a future model can simply flip it to `true`.
+    private static let unrestricted = AppleTVCapability(
+        maxResolution: 2160,
+        supportsHDR: true,
+        supportsDolbyVision: true,
+        supportsHEVCHardwareDecode: true,
+        supportsAV1HardwareDecode: false
+    )
+
+    /// Keyed by `hw.machine` identifier, not marketing name. Source: Apple's
+    /// published SoC media-engine specs per generation.
+    private static let table: [String: AppleTVCapability] = [
+        // Apple TV HD / A1625 (2015, A8). 1080p SDR ceiling; no HEVC hw decode.
+        "AppleTV5,3": AppleTVCapability(
+            maxResolution: 1080,
+            supportsHDR: false,
+            supportsDolbyVision: false,
+            supportsHEVCHardwareDecode: false,
+            supportsAV1HardwareDecode: false
+        ),
+        "AppleTV6,2": unrestricted,   // Apple TV 4K, 1st gen (2017, A10X).
+        "AppleTV11,1": unrestricted,  // Apple TV 4K, 2nd gen (2021, A12).
+        "AppleTV14,1": unrestricted,  // Apple TV 4K, 3rd gen (2022, A15).
+    ]
+
+    /// The capability profile for the device this process is running on.
+    /// Hardware this table doesn't recognize yet (including the Simulator,
+    /// whose `hw.machine` is the host Mac's architecture string) resolves to
+    /// `unrestricted` — this table should only ever narrow behavior for
+    /// models it has explicit, verified data for, never restrict a device by
+    /// default.
+    static let current: AppleTVCapability = table[hardwareIdentifier()] ?? unrestricted
+
+    /// Whether a stream carrying these tags is expected to actually play on
+    /// this device, rather than software-decode-thrash into choppy video
+    /// and/or silent audio.
+    func isPlayable(tags: StreamQualityTags) -> Bool {
+        if tags.resolution > 0, tags.resolution > maxResolution { return false }
+        if tags.isDolbyVision, !supportsDolbyVision { return false }
+        if tags.isHDR, !supportsHDR { return false }
+        return true
+    }
+
+    static func hardwareIdentifier() -> String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        return withUnsafePointer(to: &systemInfo.machine) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: 1) { String(cString: $0) }
+        }
+    }
+}

--- a/tvosApp/NuvioTV/Sources/Core/Streams/StreamQualityTags.swift
+++ b/tvosApp/NuvioTV/Sources/Core/Streams/StreamQualityTags.swift
@@ -35,8 +35,12 @@ struct StreamQualityTags: Equatable, Codable {
             " profile 5", "profile 5", " profile 7", "profile 7", " profile 8", "profile 8",
             " dv ", "dv.", ".dv.", "[dv]", "(dv)"
         ]) || text.range(of: #"\bdv\b"#, options: .regularExpression) != nil
-        tags.isHDR = tags.isDolbyVision || textContainsAny(text, [
-            "hdr10+", "hdr10", "hdr", "hlg", "pq10"
+        // Whole-word match: a plain substring check on "hdr" would false-positive
+        // on SDR releases tagged "HDRip" ("high definition rip", unrelated to HDR
+        // color). "hdr10" alone (word-bounded) already covers "hdr10+" text, since
+        // the "+" is itself a non-word character and satisfies the boundary.
+        tags.isHDR = tags.isDolbyVision || textContainsAnyWholeWord(text, [
+            "hdr10", "hdr", "hlg", "pq10"
         ])
         tags.isAtmos = textContainsAny(text, [
             "atmos", "truehd atmos", "ddp atmos", "eac3 atmos", "dd+ atmos"
@@ -110,6 +114,17 @@ struct StreamQualityTags: Equatable, Codable {
 
     private static func textContainsAny(_ text: String, _ needles: [String]) -> Bool {
         needles.contains { text.contains($0) }
+    }
+
+    /// Like `textContainsAny`, but requires each needle to appear as its own
+    /// token (word-boundary match) rather than anywhere as a substring, so a
+    /// short tag like "hdr" doesn't match inside an unrelated longer word
+    /// (e.g. "HDRip").
+    private static func textContainsAnyWholeWord(_ text: String, _ needles: [String]) -> Bool {
+        needles.contains { needle in
+            let escaped = NSRegularExpression.escapedPattern(for: needle)
+            return text.range(of: "\\b\(escaped)\\b", options: .regularExpression) != nil
+        }
     }
 }
 

--- a/tvosApp/NuvioTV/Sources/UI/Details/DetailsScreen.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Details/DetailsScreen.swift
@@ -1235,10 +1235,14 @@ enum SmartPlaybackSelector {
         // decoded frames then use MoltenVK/libplacebo's PBO upload path, which
         // MTLSimDriver can terminate as XPC API misuse. Prefer another stream;
         // physical Apple TV keeps AV1 available through its real Metal driver.
-        return !isAV1LabeledStream(stream)
-        #else
-        return true
+        if isAV1LabeledStream(stream) { return false }
         #endif
+        // Keep weaker hardware (Apple TV HD) from auto-picking or offering
+        // 4K/HDR/Dolby Vision sources it can only software-decode, which
+        // starves the CPU and produces choppy video with no audio at all.
+        // See AppleTVCapability.swift. No-op on Apple TV 4K models, which
+        // report an unrestricted ceiling.
+        return AppleTVCapability.current.isPlayable(tags: StreamQualityTags.parse(stream: stream))
     }
 
 }

--- a/tvosApp/NuvioTVTests/AppleTVCapabilityTests.swift
+++ b/tvosApp/NuvioTVTests/AppleTVCapabilityTests.swift
@@ -33,6 +33,15 @@ final class AppleTVCapabilityTests: XCTestCase {
         XCTAssertTrue(appleTVHD.isPlayable(tags: tags))
     }
 
+    func testAppleTVHDAcceptsHDRipRelease() {
+        // Regression: "HDRip" ("high definition rip") is an SDR release tag,
+        // not HDR content. It must not get caught by the HDR-only exclusion
+        // above (see StreamQualityTagsTests.testHDRipIsNotDetectedAsHDR for
+        // the underlying tag-parsing fix).
+        let tags = StreamQualityTags.parse(name: "Movie 1080p HDRip x264")
+        XCTAssertTrue(appleTVHD.isPlayable(tags: tags))
+    }
+
     func testAppleTVHDAcceptsUntaggedStream() {
         // A stream with no parseable resolution/HDR markers should never be
         // blocked outright by capability filtering alone.

--- a/tvosApp/NuvioTVTests/AppleTVCapabilityTests.swift
+++ b/tvosApp/NuvioTVTests/AppleTVCapabilityTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import NuvioTV
+
+final class AppleTVCapabilityTests: XCTestCase {
+    private let appleTVHD = AppleTVCapability(
+        maxResolution: 1080,
+        supportsHDR: false,
+        supportsDolbyVision: false,
+        supportsHEVCHardwareDecode: false,
+        supportsAV1HardwareDecode: false
+    )
+
+    private let appleTV4K = AppleTVCapability(
+        maxResolution: 2160,
+        supportsHDR: true,
+        supportsDolbyVision: true,
+        supportsHEVCHardwareDecode: true,
+        supportsAV1HardwareDecode: false
+    )
+
+    func testAppleTVHDRejects4KDolbyVision() {
+        let tags = StreamQualityTags.parse(name: "Movie 2160p Dolby Vision")
+        XCTAssertFalse(appleTVHD.isPlayable(tags: tags))
+    }
+
+    func testAppleTVHDRejectsHDROnlyAtAnyResolution() {
+        let tags = StreamQualityTags.parse(name: "Movie 1080p HDR10")
+        XCTAssertFalse(appleTVHD.isPlayable(tags: tags))
+    }
+
+    func testAppleTVHDAccepts1080pSDR() {
+        let tags = StreamQualityTags.parse(name: "Movie 1080p WEB-DL")
+        XCTAssertTrue(appleTVHD.isPlayable(tags: tags))
+    }
+
+    func testAppleTVHDAcceptsUntaggedStream() {
+        // A stream with no parseable resolution/HDR markers should never be
+        // blocked outright by capability filtering alone.
+        let tags = StreamQualityTags.parse(name: "Movie")
+        XCTAssertTrue(appleTVHD.isPlayable(tags: tags))
+    }
+
+    func testAppleTV4KAccepts4KDolbyVision() {
+        let tags = StreamQualityTags.parse(name: "Movie 2160p Dolby Vision")
+        XCTAssertTrue(appleTV4K.isPlayable(tags: tags))
+    }
+
+    func testUnknownHardwareIdentifierDefaultsToUnrestricted() {
+        // Anything not in the table (including the Simulator's host
+        // architecture string) must never be narrowed by default.
+        XCTAssertFalse(AppleTVCapability.hardwareIdentifier().isEmpty)
+    }
+}

--- a/tvosApp/NuvioTVTests/StreamQualityTagsTests.swift
+++ b/tvosApp/NuvioTVTests/StreamQualityTagsTests.swift
@@ -14,6 +14,22 @@ final class StreamQualityTagsTests: XCTestCase {
         XCTAssertTrue(tags.isAtmos)
     }
 
+    func testHDRipIsNotDetectedAsHDR() {
+        // "HDRip" ("high definition rip") is an SDR release tag; a naive
+        // substring match on "hdr" would false-positive on it.
+        let tags = StreamQualityTags.parse(name: "Movie 1080p HDRip x264")
+        XCTAssertFalse(tags.isHDR)
+        XCTAssertFalse(tags.isDolbyVision)
+    }
+
+    func testHDRTokensStillDetectedAsHDR() {
+        XCTAssertTrue(StreamQualityTags.parse(name: "Movie 2160p HDR x265").isHDR)
+        XCTAssertTrue(StreamQualityTags.parse(name: "Movie 2160p HDR10 x265").isHDR)
+        XCTAssertTrue(StreamQualityTags.parse(name: "Movie 2160p HDR10+ x265").isHDR)
+        XCTAssertTrue(StreamQualityTags.parse(name: "Movie 2160p HLG x265").isHDR)
+        XCTAssertTrue(StreamQualityTags.parse(name: "Movie 2160p PQ10 x265").isHDR)
+    }
+
     func testParsesCachedMarkers() {
         let cached = StreamQualityTags.parse(name: "⚡ 1080p RD+", description: "Cached")
         XCTAssertTrue(cached.isCached)


### PR DESCRIPTION
## Summary

Apple TV HD (`AppleTV5,3`, A8 SoC) has no hardware HEVC decoder and is capped at 1080p SDR output. `SmartPlaybackSelector` currently has no awareness of this and will auto-pick (or offer) 4K/HDR/Dolby Vision sources it can only software-decode, which saturates the CPU and produces choppy video with completely silent audio. Adds `AppleTVCapability`, a small `hw.machine`-keyed table of real per-model decode ceilings wired into the existing `isPlatformPlaybackCompatible` gate. Apple TV 4K (all 3 generations) keeps an unrestricted ceiling, so this only changes behavior on Apple TV HD. Also fixes a review-flagged false positive where `StreamQualityTags.isHDR` matched "hdr" as a substring, incorrectly flagging normal SDR "HDRip" releases as HDR.

## PR type

- [x] Behavior bug/regression fix

## Why

On physical Apple TV HD hardware, playing a 4K and/or Dolby Vision/HDR stream produces choppy video and zero audio for the entire session, not degraded-but-working playback. `audioFifo` stayed at 0 the whole time and `[VTProbe] canHardwareDecode codec=173 3840x2160 -> false` confirms the hardware genuinely can't decode it. There's no device-capability-aware filtering anywhere in the stream selection code today.

## Issue or approval

Fixes #12

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only filters by resolution + HDR/Dolby Vision support, since that's what's evidenced by the reported failure (4K Dolby Vision HEVC). Does not add bitrate-based ranking or H.264-vs-HEVC preference — no evidence yet that those are needed beyond the 4K/HDR case, and adding them without evidence would be scope creep. Does not change Apple TV 4K behavior (unrestricted ceiling, same as before this PR). Does not touch `PlaybackBackendPolicy` (Aether/MPV engine selection) or any UI.

## Testing

- Unit tests added and passing: `AppleTVCapabilityTests` (7 tests) and 2 new cases in `StreamQualityTagsTests` (HDRip non-match + real HDR tokens still match), run via `xcodebuild test -scheme NuvioTV -destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation)'`. Full existing `StreamQualityTagsTests` suite (10 tests) still passes, confirming no regression.
- Manually verified on a physical Apple TV HD (tvOS 26.5): before this change, a 4K Dolby Vision stream played with choppy video and no audio; after, the picker skips it in favor of a compatible source.
- Manually verified the false-positive fix: a stream named "HDRip" is no longer excluded on Apple TV HD.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #12