### PR TITLE
Feat: Netflix style search view

### DIFF
--- a/tvosApp/NuvioTV.xcodeproj/project.pbxproj
+++ b/tvosApp/NuvioTV.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		7E51000000000000000000B1 /* TopShelf.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 7E51000000000000000000A1 /* TopShelf.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7E51000000000000000000B2 /* TopShelf/TopShelfContentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E51000000000000000000A2 /* TopShelf/TopShelfContentProvider.swift */; };
 		7E51000000000000000000B3 /* NuvioTV/Sources/Core/TopShelf/TopShelfFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300390000000000000039 /* NuvioTV/Sources/Core/TopShelf/TopShelfFeed.swift */; };
+		A17000000000000000000011 /* NuvioTV/Sources/UI/Search/NetflixSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17000000000000000000001 /* NuvioTV/Sources/UI/Search/NetflixSearchView.swift */; };
+		A17000000000000000000012 /* NuvioTV/Sources/ViewModels/NetflixSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17000000000000000000002 /* NuvioTV/Sources/ViewModels/NetflixSearchViewModel.swift */; };
 		A1L100020000000000000002 /* NuvioTV/Sources/Core/AppLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1L100010000000000000001 /* NuvioTV/Sources/Core/AppLanguage.swift */; };
 		A1L100040000000000000004 /* NuvioTV/Resources/AppLanguageCatalog.json in Resources */ = {isa = PBXBuildFile; fileRef = A1L100030000000000000003 /* NuvioTV/Resources/AppLanguageCatalog.json */; };
 		AE00BF010000000000000001 /* AetherEngine in Frameworks */ = {isa = PBXBuildFile; productRef = AE00PD010000000000000001 /* AetherEngine */; };
@@ -205,6 +207,7 @@
 		C0D300150000000000000015 /* NuvioTV/Sources/UI/Profile/ProfilePinView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/UI/Profile/ProfilePinView.swift; sourceTree = "<group>"; };
 		C0D300160000000000000016 /* NuvioTV/Sources/UI/Profile/UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/UI/Profile/UserProfileView.swift; sourceTree = "<group>"; };
 		C0D300170000000000000017 /* NuvioTV/Sources/UI/Search/SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/UI/Search/SearchView.swift; sourceTree = "<group>"; };
+		A17000000000000000000001 /* NuvioTV/Sources/UI/Search/NetflixSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/UI/Search/NetflixSearchView.swift; sourceTree = "<group>"; };
 		C0D300180000000000000018 /* NuvioTV/Sources/UI/Settings/SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/UI/Settings/SettingsView.swift; sourceTree = "<group>"; };
 		C0D300190000000000000019 /* NuvioTV/Sources/UI/Addons/AddonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/UI/Addons/AddonsView.swift; sourceTree = "<group>"; };
 		C0D3001A000000000000001A /* NuvioTV/Sources/UI/Details/DetailsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/UI/Details/DetailsScreen.swift; sourceTree = "<group>"; };
@@ -213,6 +216,7 @@
 		C0D3001E000000000000001E /* NuvioTV/Sources/ViewModels/PlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/ViewModels/PlayerViewModel.swift; sourceTree = "<group>"; };
 		C0D3001F000000000000001F /* NuvioTV/Sources/ViewModels/ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/ViewModels/ProfileViewModel.swift; sourceTree = "<group>"; };
 		C0D300200000000000000020 /* NuvioTV/Sources/ViewModels/SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/ViewModels/SearchViewModel.swift; sourceTree = "<group>"; };
+		A17000000000000000000002 /* NuvioTV/Sources/ViewModels/NetflixSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/ViewModels/NetflixSearchViewModel.swift; sourceTree = "<group>"; };
 		C0D300220000000000000022 /* NuvioTV/Sources/DomainModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/DomainModels.swift; sourceTree = "<group>"; };
 		C0D300230000000000000023 /* NuvioTV/Sources/Core/Auth/AuthConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Auth/AuthConfig.swift; sourceTree = "<group>"; };
 		C0D300240000000000000024 /* NuvioTV/Sources/Core/Auth/AuthModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Auth/AuthModels.swift; sourceTree = "<group>"; };
@@ -406,6 +410,7 @@
 				C0D300150000000000000015 /* NuvioTV/Sources/UI/Profile/ProfilePinView.swift */,
 				C0D300160000000000000016 /* NuvioTV/Sources/UI/Profile/UserProfileView.swift */,
 				C0D300170000000000000017 /* NuvioTV/Sources/UI/Search/SearchView.swift */,
+				A17000000000000000000001 /* NuvioTV/Sources/UI/Search/NetflixSearchView.swift */,
 				C0D300180000000000000018 /* NuvioTV/Sources/UI/Settings/SettingsView.swift */,
 				C0D300190000000000000019 /* NuvioTV/Sources/UI/Addons/AddonsView.swift */,
 				C0D3001A000000000000001A /* NuvioTV/Sources/UI/Details/DetailsScreen.swift */,
@@ -427,6 +432,7 @@
 				C0D30054 /* NuvioTV/Sources/Core/Player/PlaybackWakeLock.swift */,
 				C0D3001F000000000000001F /* NuvioTV/Sources/ViewModels/ProfileViewModel.swift */,
 				C0D300200000000000000020 /* NuvioTV/Sources/ViewModels/SearchViewModel.swift */,
+				A17000000000000000000002 /* NuvioTV/Sources/ViewModels/NetflixSearchViewModel.swift */,
 				C0D300220000000000000022 /* NuvioTV/Sources/DomainModels.swift */,
 				C0D300230000000000000023 /* NuvioTV/Sources/Core/Auth/AuthConfig.swift */,
 				C0D300240000000000000024 /* NuvioTV/Sources/Core/Auth/AuthModels.swift */,
@@ -715,6 +721,7 @@
 				C0D310150000000000000015 /* NuvioTV/Sources/UI/Profile/ProfilePinView.swift in Sources */,
 				C0D310160000000000000016 /* NuvioTV/Sources/UI/Profile/UserProfileView.swift in Sources */,
 				C0D310170000000000000017 /* NuvioTV/Sources/UI/Search/SearchView.swift in Sources */,
+				A17000000000000000000011 /* NuvioTV/Sources/UI/Search/NetflixSearchView.swift in Sources */,
 				C0D310180000000000000018 /* NuvioTV/Sources/UI/Settings/SettingsView.swift in Sources */,
 				C0D310190000000000000019 /* NuvioTV/Sources/UI/Addons/AddonsView.swift in Sources */,
 				C0D3101A000000000000001A /* NuvioTV/Sources/UI/Details/DetailsScreen.swift in Sources */,
@@ -737,6 +744,7 @@
 				C0D31054 /* NuvioTV/Sources/Core/Player/PlaybackWakeLock.swift in Sources */,
 				C0D3101F000000000000001F /* NuvioTV/Sources/ViewModels/ProfileViewModel.swift in Sources */,
 				C0D310200000000000000020 /* NuvioTV/Sources/ViewModels/SearchViewModel.swift in Sources */,
+				A17000000000000000000012 /* NuvioTV/Sources/ViewModels/NetflixSearchViewModel.swift in Sources */,
 				C0D310220000000000000022 /* NuvioTV/Sources/DomainModels.swift in Sources */,
 				C0D310230000000000000023 /* NuvioTV/Sources/Core/Auth/AuthConfig.swift in Sources */,
 				C0D310240000000000000024 /* NuvioTV/Sources/Core/Auth/AuthModels.swift in Sources */,

--- a/tvosApp/NuvioTV/Sources/NuvioTVApp.swift
+++ b/tvosApp/NuvioTV/Sources/NuvioTVApp.swift
@@ -149,7 +149,12 @@ struct ContentView: View {
     @StateObject private var authManager = AuthManager()
     @StateObject private var profileViewModel = ProfileViewModel()
     @StateObject private var syncManager = NuvioSyncManager()
+    // Both search screens are backed by their own view model. Only the one
+    // picked by `SettingsKey.searchStyle` is rendered, but both are held here
+    // so switching styles doesn't tear down and refetch the other's state.
+    // They share the same recent-search storage key.
     @StateObject private var searchViewModel = SearchViewModel()
+    @StateObject private var netflixSearchViewModel = NetflixSearchViewModel()
     @StateObject private var libraryViewModel = LibraryViewModel()
     // Owned here (not inside TVHomeView) so the Home catalog + focused card
     // survive the details/player push, which tears TVHomeView down. Returning
@@ -1196,6 +1201,7 @@ struct ContentView: View {
             selectedTab: $selectedTab,
             activeProfile: profileViewModel.activeProfile,
             searchViewModel: searchViewModel,
+            netflixSearchViewModel: netflixSearchViewModel,
             libraryViewModel: libraryViewModel,
             homeStore: homeStore,
             homeCatalogRevision: syncManager.homeCatalogRevision,
@@ -1256,6 +1262,8 @@ struct ContentView: View {
                 homeStore.reset()
                 searchViewModel.clear()
                 searchViewModel.clearRecent()
+                netflixSearchViewModel.clear()
+                netflixSearchViewModel.clearRecent()
                 withAnimation(.easeInOut(duration: 0.28)) {
                     selectedTab = .home
                     profileViewModel.activeProfile = nil
@@ -1924,6 +1932,7 @@ private struct TVMainTabView: View {
     @Binding var selectedTab: TVTab
     let activeProfile: Profile?
     @ObservedObject var searchViewModel: SearchViewModel
+    @ObservedObject var netflixSearchViewModel: NetflixSearchViewModel
     @ObservedObject var libraryViewModel: LibraryViewModel
     @ObservedObject var homeStore: TVHomeStore
     let homeCatalogRevision: UInt
@@ -1951,6 +1960,7 @@ private struct TVMainTabView: View {
     @AppStorage(SettingsKey.amoled) private var amoled = false
     @AppStorage(SettingsKey.bodyColor) private var bodyColor = SettingsBackground.charcoal.rawValue
     @AppStorage(SettingsKey.discoverLocation) private var discoverLocation = "Search"
+    @AppStorage(SettingsKey.searchStyle) private var searchStyle = "Netflix"
     @AppStorage(SettingsKey.profileName) private var settingsProfileName = "Nuvio User"
     @StateObject private var profileTabAvatar = ProfileTabAvatarRenderer()
 
@@ -1972,6 +1982,26 @@ private struct TVMainTabView: View {
                 .tabViewStyle(.sidebarAdaptable)
         } else {
             tabs
+        }
+    }
+
+    /// Search screen chosen in Settings → Layout & Discovery → Search Style.
+    @ViewBuilder
+    private var searchTab: some View {
+        if searchStyle == "Classic" {
+            SearchView(
+                viewModel: searchViewModel,
+                showDiscover: discoverLocation == "Search",
+                onContentClick: onNavigateToDetails,
+                onLongPress: onLongPressCard
+            )
+        } else {
+            NetflixSearchView(
+                viewModel: netflixSearchViewModel,
+                showDiscover: discoverLocation == "Search",
+                onContentClick: onNavigateToDetails,
+                onLongPress: onLongPressCard
+            )
         }
     }
 
@@ -2021,12 +2051,7 @@ private struct TVMainTabView: View {
                 }
                 .tag(TVTab.home)
 
-            SearchView(
-                viewModel: searchViewModel,
-                showDiscover: discoverLocation == "Search",
-                onContentClick: onNavigateToDetails,
-                onLongPress: onLongPressCard
-            )
+            searchTab
                 .tabItem {
                     Label(TVTab.search.title, systemImage: TVTab.search.symbol)
                 }

--- a/tvosApp/NuvioTV/Sources/UI/Components/PosterCard.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Components/PosterCard.swift
@@ -699,6 +699,9 @@ struct PosterGridCard: View {
     var onInitialFocusRequested: (() -> Void)? = nil
     var onFocus: ((NuvioMeta) -> Void)? = nil
     var onLongPress: (() -> Void)? = nil
+    /// Forces the title/subtitle caption to render regardless of the user's
+    /// global poster-labels setting (used by Search's Netflix-style grid).
+    var forceShowLabels = false
     let action: () -> Void
 
     @FocusState private var focused: Bool
@@ -747,7 +750,7 @@ struct PosterGridCard: View {
                     radius: showsFocusedAppearance ? 16 : 6
                 )
 
-                if posterLabels {
+                if posterLabels || forceShowLabels {
                     VStack(alignment: .leading, spacing: 3) {
                         Text(meta.name)
                             .font(.system(size: 20, weight: .semibold))

--- a/tvosApp/NuvioTV/Sources/UI/Search/NetflixSearchView.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Search/NetflixSearchView.swift
@@ -1,0 +1,597 @@
+import SwiftUI
+
+/// Netflix-style alternative to `SearchView`: an always-visible, embedded
+/// on-screen keyboard (no modal system keyboard) with results split into a
+/// text index on the left and a poster grid on the right, mirroring the
+/// tvOS Netflix search screen. Wired to the same `CatalogRepository` search
+/// use case as `SearchView` via `NetflixSearchViewModel`.
+///
+/// Reuses `PosterGridCard`, `GlassChip`, `GlassChipBackground`,
+/// `GlassSearchBar`, `PosterCardButtonStyle`, `DiscoverSection`,
+/// `SearchContentType`, `ContentReleasePolicy` and the hidden-text-field
+/// dictation fallback from `SearchView.swift` rather than duplicating them.
+/// The keyboard is the one place that can't reuse `GlassChip`: it needs
+/// fixed-width keys to guarantee a no-scroll fit (see `NetflixKeyboardKey`).
+private enum NetflixSearchMetrics {
+    /// Sits on top of tvOS's own ~80pt overscan safe area, so this only needs
+    /// to be big enough that a focused key/card's scale-up doesn't visually
+    /// touch the safe-area boundary.
+    static let pageInset: CGFloat = 8
+    static let posterWidth: CGFloat = 190
+    static let posterHeight: CGFloat = 285
+    static let posterGap: CGFloat = 24
+    static let listWidth: CGFloat = 440
+    static let columnGap: CGFloat = 32
+    /// Keys are sized so all 29 of them (26 letters + 123/Space/delete) fit on
+    /// one 1080p line. `KeyboardFlowLayout` wraps to a second line rather than
+    /// scrolling if a narrower viewport can't fit them.
+    static let keyHeight: CGFloat = 54
+    static let letterKeyWidth: CGFloat = 46
+    static let toggleKeyWidth: CGFloat = 76
+    static let spaceKeyWidth: CGFloat = 116
+    static let deleteKeyWidth: CGFloat = 64
+    static let keyHGap: CGFloat = 8
+    static let keyVGap: CGFloat = 10
+}
+
+private enum NetflixKeyboardMode {
+    case letters, numbers
+
+    var keys: [String] {
+        switch self {
+        case .letters: return (UnicodeScalar("a").value...UnicodeScalar("z").value)
+            .compactMap { UnicodeScalar($0).map(String.init) }
+        case .numbers: return (0...9).map(String.init)
+        }
+    }
+
+    var toggleLabel: String {
+        switch self {
+        case .letters: return "123"
+        case .numbers: return "ABC"
+        }
+    }
+}
+
+struct NetflixSearchView: View {
+    @StateObject private var viewModel: NetflixSearchViewModel
+    let showDiscover: Bool
+    let onContentClick: (String, String) -> Void
+    var onLongPress: ((NuvioMeta) -> Void)? = nil
+
+    /// One shared focus id-space for both the text list and the poster grid,
+    /// namespaced ("list:"/"grid:") so the same result can be focused in
+    /// either column without the two bindings fighting over one id.
+    @FocusState private var focusedItemID: String?
+    @FocusState private var clearRecentFocused: Bool
+    @FocusState private var dictateFocused: Bool
+    @State private var keyboardMode: NetflixKeyboardMode = .letters
+    /// Same overlay-restore dance as `SearchView`: Details is a sibling
+    /// overlay (not a navigation push), so returning from it needs to
+    /// re-place focus geometrically instead of snapping to the first result.
+    @State private var lastFocusedItemID: String?
+    @State private var shouldRestoreFocus = false
+    @State private var overlayRestoreItemID: String?
+    @State private var overlayRestoreGeneration = 0
+    @State private var discoverOverlayTransitionActive = false
+    @Environment(\.isEnabled) private var isEnabled
+    /// True while the hidden text field is first responder, i.e. the system
+    /// keyboard (with its own Siri dictation button) is covering the screen
+    /// as a dictation fallback. The embedded keyboard has no way to hook the
+    /// remote's physical mic button itself.
+    @State private var systemDictationActive = false
+    @AppStorage(SettingsKey.amoled) private var amoled = false
+    @AppStorage(SettingsKey.bodyColor) private var bodyColor = SettingsBackground.charcoal.rawValue
+    @AppStorage(SettingsKey.hideUnreleased) private var hideUnreleased = false
+
+    init(viewModel: NetflixSearchViewModel, showDiscover: Bool = true, onContentClick: @escaping (String, String) -> Void, onLongPress: ((NuvioMeta) -> Void)? = nil) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+        self.showDiscover = showDiscover
+        self.onContentClick = onContentClick
+        self.onLongPress = onLongPress
+    }
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            Color.nuvioBackground(amoled: amoled, body: bodyColor).ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: 20) {
+                queryHeader
+                    .disabled(overlayRestoreItemID != nil || discoverOverlayTransitionActive)
+                keyboard
+                    .disabled(overlayRestoreItemID != nil || discoverOverlayTransitionActive)
+                Rectangle()
+                    .fill(Color.white.opacity(0.14))
+                    .frame(height: 1)
+
+                if viewModel.hasQuery {
+                    typeFilterRow
+                        .disabled(overlayRestoreItemID != nil)
+                    resultsBody
+                } else {
+                    if !viewModel.recentSearches.isEmpty {
+                        recentRow
+                            .disabled(discoverOverlayTransitionActive)
+                    }
+                    if showDiscover {
+                        DiscoverSection(
+                            onContentClick: onContentClick,
+                            onLongPress: onLongPress,
+                            parentTransitionActive: $discoverOverlayTransitionActive
+                        )
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    } else {
+                        centeredState {
+                            messageState(
+                                icon: "rectangle.grid.2x2",
+                                title: L10n.string(
+                                    "search_start_subtitle_no_discover",
+                                    fallback: "Discover is disabled. Enter at least 2 characters"
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, NetflixSearchMetrics.pageInset)
+            .padding(.top, 16)
+            .ignoresSafeArea(.container, edges: .bottom)
+
+            // Off-screen; becomes first responder only for the dictation
+            // fallback (see `dictateButton`). Reused from `SearchView.swift`.
+            HiddenSearchTextField(text: $viewModel.searchText, isEditing: $systemDictationActive)
+                .frame(width: 1, height: 1)
+                .offset(x: -4_000)
+                .allowsHitTesting(false)
+        }
+        .onAppear {
+            viewModel.reloadRecent()
+        }
+        .onChange(of: focusedItemID) { newValue in
+            if let newValue {
+                lastFocusedItemID = newValue
+                shouldRestoreFocus = false
+                if isEnabled, newValue == overlayRestoreItemID { overlayRestoreItemID = nil }
+            } else if lastFocusedItemID != nil {
+                shouldRestoreFocus = true
+            }
+        }
+        .onChange(of: isEnabled) { enabled in
+            if !enabled {
+                overlayRestoreGeneration &+= 1
+                overlayRestoreItemID = focusedItemID ?? lastFocusedItemID
+            } else if let target = overlayRestoreItemID {
+                restoreOverlayFocus(to: target, generation: overlayRestoreGeneration)
+            }
+        }
+    }
+
+    private func restoreOverlayFocus(to target: String, generation: Int) {
+        for delay in [0.12, 0.45] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                if overlayRestoreGeneration == generation, overlayRestoreItemID == target {
+                    focusedItemID = target
+                }
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            if overlayRestoreGeneration == generation, overlayRestoreItemID == target {
+                overlayRestoreItemID = nil
+            }
+        }
+    }
+
+    // MARK: - Header: query readout + dictate
+
+    private var queryHeader: some View {
+        HStack(spacing: 24) {
+            HStack(spacing: 16) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 26, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.7))
+                Text(
+                    viewModel.searchText.isEmpty
+                        ? L10n.string("search_placeholder", fallback: "Search for movies and TV shows")
+                        : viewModel.searchText
+                )
+                    .textCase(.uppercase)
+                    .font(.system(size: 26, weight: .medium))
+                    .foregroundColor(viewModel.searchText.isEmpty ? .white.opacity(0.45) : .white)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 26)
+            .frame(height: 58)
+            .frame(maxWidth: 720, alignment: .leading)
+            .modifier(GlassSearchBar(focused: false))
+
+            Spacer(minLength: 0)
+
+            dictateButton
+        }
+    }
+
+    private var dictateButton: some View {
+        Button {
+            systemDictationActive = true
+        } label: {
+            HStack(spacing: 12) {
+                Text(L10n.string("search_dictate_hint", fallback: "Press to dictate"))
+                    .font(.system(size: 20, weight: .medium))
+                Image(systemName: "mic.fill")
+                    .font(.system(size: 20, weight: .semibold))
+                    .padding(6)
+                    .background(Circle().fill(Color.white.opacity(dictateFocused ? 1 : 0.16)))
+                    .foregroundColor(dictateFocused ? .black : .white)
+            }
+            .foregroundColor(.white.opacity(0.75))
+        }
+        .buttonStyle(PosterCardButtonStyle())
+        .focused($dictateFocused)
+        .focusEffectDisabledIfAvailable()
+        .scaleEffect(dictateFocused ? 1.05 : 1.0)
+        .animation(.easeOut(duration: 0.14), value: dictateFocused)
+    }
+
+    // MARK: - Embedded keyboard
+
+    private var keyboard: some View {
+        KeyboardFlowLayout(
+            hSpacing: NetflixSearchMetrics.keyHGap,
+            vSpacing: NetflixSearchMetrics.keyVGap
+        ) {
+            NetflixKeyboardKey(
+                label: keyboardMode.toggleLabel,
+                width: NetflixSearchMetrics.toggleKeyWidth
+            ) {
+                keyboardMode = keyboardMode == .letters ? .numbers : .letters
+            }
+
+            NetflixKeyboardKey(
+                label: L10n.string("search_keyboard_space", fallback: "Space"),
+                width: NetflixSearchMetrics.spaceKeyWidth
+            ) {
+                viewModel.typeCharacter(" ")
+            }
+
+            ForEach(keyboardMode.keys, id: \.self) { key in
+                NetflixKeyboardKey(
+                    label: key,
+                    width: NetflixSearchMetrics.letterKeyWidth
+                ) {
+                    viewModel.typeCharacter(key)
+                }
+            }
+
+            NetflixKeyboardKey(
+                label: "",
+                systemImage: "delete.left",
+                width: NetflixSearchMetrics.deleteKeyWidth
+            ) {
+                viewModel.deleteLastCharacter()
+            }
+        }
+        .focusSection()
+    }
+
+    // MARK: - Type filter
+
+    private var typeFilterRow: some View {
+        HStack(spacing: 16) {
+            ForEach(SearchContentType.allCases) { type in
+                GlassChip(title: type.title, isSelected: viewModel.selectedType == type) {
+                    viewModel.setType(type)
+                }
+            }
+
+            Spacer()
+
+            if !visibleResults.isEmpty {
+                Text(resultsCountLabel)
+                    .font(.system(size: 22, weight: .medium))
+                    .foregroundColor(.white.opacity(0.5))
+            }
+        }
+    }
+
+    // MARK: - Results: text list + poster grid
+
+    private var visibleResults: [NuvioMeta] {
+        guard hideUnreleased else { return viewModel.results }
+        return viewModel.results.filter { !ContentReleasePolicy.isUnreleased($0) }
+    }
+
+    private var resultsCountLabel: String {
+        let count = visibleResults.count
+        if count == 1 {
+            return L10n.format("tvos_search_result_count_one", fallback: "%d result", count)
+        }
+        return L10n.format("tvos_search_result_count_other", fallback: "%d results", count)
+    }
+
+    @ViewBuilder
+    private var resultsBody: some View {
+        if viewModel.isLoading {
+            centeredState {
+                ProgressView()
+                    .scaleEffect(1.6)
+                    .tint(.white)
+            }
+        } else if let error = viewModel.error {
+            centeredState {
+                messageState(icon: "wifi.exclamationmark", title: error)
+            }
+        } else if visibleResults.isEmpty {
+            centeredState {
+                messageState(
+                    icon: "magnifyingglass",
+                    title: L10n.string("search_no_results_title", fallback: "No Results"),
+                    subtitle: L10n.format(
+                        "tvos_search_no_results_for",
+                        fallback: "No results for “%@”",
+                        viewModel.searchText
+                    )
+                )
+            }
+        } else {
+            HStack(alignment: .top, spacing: NetflixSearchMetrics.columnGap) {
+                resultsList
+                resultsGrid
+            }
+        }
+    }
+
+    private var resultsList: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 8) {
+                ForEach(visibleResults) { item in
+                    let focusID = "list:\(item.id)"
+                    let isFocused = focusedItemID == focusID
+                    Button {
+                        overlayRestoreItemID = focusID
+                        lastFocusedItemID = focusID
+                        onContentClick(item.id, item.type)
+                    } label: {
+                        Text(item.name)
+                            .font(.system(size: 24, weight: isFocused ? .bold : .regular))
+                            .foregroundColor(isFocused ? .black : .white.opacity(0.85))
+                            .lineLimit(1)
+                            .padding(.horizontal, 20)
+                            .frame(height: 54)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .modifier(GlassChipBackground(filled: isFocused))
+                    }
+                    .buttonStyle(PosterCardButtonStyle())
+                    .focused($focusedItemID, equals: focusID)
+                    .focusEffectDisabledIfAvailable()
+                    .disabled(overlayRestoreItemID != nil && overlayRestoreItemID != focusID)
+                }
+            }
+            .padding(.top, 6)
+            .padding(.bottom, 40)
+        }
+        .frame(width: NetflixSearchMetrics.listWidth)
+        .focusSection()
+        .defaultFocusIfAvailable($focusedItemID, defaultItemFocusID)
+    }
+
+    private var resultsGrid: some View {
+        ScrollView {
+            LazyVGrid(columns: gridColumns, alignment: .leading, spacing: NetflixSearchMetrics.posterGap) {
+                ForEach(visibleResults) { item in
+                    let focusID = "grid:\(item.id)"
+                    PosterGridCard(
+                        meta: item,
+                        width: NetflixSearchMetrics.posterWidth,
+                        height: NetflixSearchMetrics.posterHeight,
+                        externalFocus: $focusedItemID,
+                        focusValue: focusID,
+                        retainFocusAppearance: overlayRestoreItemID == focusID,
+                        onLongPress: onLongPress.map { cb in { cb(item) } },
+                        forceShowLabels: true
+                    ) {
+                        overlayRestoreItemID = focusID
+                        lastFocusedItemID = focusID
+                        onContentClick(item.id, item.type)
+                    }
+                    .disabled(overlayRestoreItemID != nil && overlayRestoreItemID != focusID)
+                }
+            }
+            // Top room so a focused card's 1.06 scale isn't clipped by the
+            // viewport edge; bottom room so the last row can scroll clear.
+            .padding(.top, 12)
+            .padding(.bottom, 40)
+        }
+        .focusSection()
+    }
+
+    /// List row the results area should focus when it (re)gains focus: the
+    /// row the user left on when armed and still present, else the first one.
+    private var defaultItemFocusID: String? {
+        if shouldRestoreFocus,
+           let saved = lastFocusedItemID,
+           saved.hasPrefix("list:"),
+           visibleResults.contains(where: { "list:\($0.id)" == saved }) {
+            return saved
+        }
+        return visibleResults.first.map { "list:\($0.id)" }
+    }
+
+    private var gridColumns: [GridItem] {
+        [GridItem(
+            .adaptive(minimum: NetflixSearchMetrics.posterWidth, maximum: NetflixSearchMetrics.posterWidth),
+            spacing: NetflixSearchMetrics.posterGap,
+            alignment: .top
+        )]
+    }
+
+    // MARK: Recent searches (shown above Discover when idle)
+
+    private var recentRow: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(L10n.string("search_recent_title", fallback: "Recent searches"))
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundColor(.white.opacity(0.8))
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    ForEach(viewModel.recentSearches, id: \.self) { term in
+                        GlassChip(title: term, isSelected: false, leadingSystemImage: "clock.arrow.circlepath") {
+                            viewModel.applyRecent(term)
+                        }
+                    }
+
+                    Button { viewModel.clearRecent() } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: "trash")
+                            Text(L10n.string("action_clear", fallback: "Clear"))
+                        }
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundColor(clearRecentFocused ? .black : .white.opacity(0.85))
+                        .padding(.horizontal, 22)
+                        .frame(height: 50)
+                        .modifier(GlassChipBackground(filled: clearRecentFocused))
+                    }
+                    .buttonStyle(PosterCardButtonStyle())
+                    .focused($clearRecentFocused)
+                    .focusEffectDisabledIfAvailable()
+                    .scaleEffect(clearRecentFocused ? 1.06 : 1.0)
+                    .animation(.easeOut(duration: 0.14), value: clearRecentFocused)
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 4)
+                .padding(.trailing, 80)
+            }
+            .scrollClipDisabledIfAvailable()
+        }
+    }
+
+    // MARK: - Shared states
+
+    private func centeredState<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        VStack {
+            Spacer(minLength: 40)
+            content()
+            Spacer(minLength: 40)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func messageState(icon: String, title: String, subtitle: String? = nil) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: icon)
+                .font(.system(size: 64, weight: .light))
+                .foregroundColor(.white.opacity(0.4))
+            Text(title)
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundColor(.white.opacity(0.8))
+                .multilineTextAlignment(.center)
+            if let subtitle {
+                Text(subtitle)
+                    .font(.system(size: 22))
+                    .foregroundColor(.white.opacity(0.5))
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: 700)
+    }
+}
+
+// MARK: - Keyboard key
+
+/// Fixed-width keyboard key. `GlassChip` sizes itself from its text plus 30pt
+/// of horizontal padding, which is far too wide for single characters, so keys
+/// take an explicit width instead.
+private struct NetflixKeyboardKey: View {
+    let label: String
+    var systemImage: String? = nil
+    let width: CGFloat
+    let action: () -> Void
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        Button(action: action) {
+            Group {
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .font(.system(size: 22, weight: .semibold))
+                } else {
+                    Text(label)
+                        .font(.system(size: 24, weight: .semibold))
+                }
+            }
+            .foregroundColor(focused ? .black : .white.opacity(0.85))
+            .frame(width: width, height: NetflixSearchMetrics.keyHeight)
+            .modifier(GlassChipBackground(filled: focused))
+        }
+        .buttonStyle(PosterCardButtonStyle())
+        .focused($focused)
+        .focusEffectDisabledIfAvailable()
+        .scaleEffect(focused ? 1.08 : 1.0)
+        .animation(.easeOut(duration: 0.14), value: focused)
+    }
+}
+
+// MARK: - Wrapping keyboard layout
+
+/// Lays keys out left-to-right, wrapping onto another line when the next key
+/// wouldn't fit. The keyboard must never scroll — every key has to be visible
+/// and directly reachable — so overflow becomes a second row instead.
+private struct KeyboardFlowLayout: Layout {
+    let hSpacing: CGFloat
+    let vSpacing: CGFloat
+
+    private struct Row {
+        var indices: [Int] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let rows = rows(for: subviews, maxWidth: maxWidth)
+        let height = rows.reduce(0) { $0 + $1.height }
+            + vSpacing * CGFloat(max(0, rows.count - 1))
+        let widest = rows.map(\.width).max() ?? 0
+        return CGSize(width: maxWidth.isFinite ? maxWidth : widest, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var y = bounds.minY
+        for row in rows(for: subviews, maxWidth: bounds.width) {
+            var x = bounds.minX
+            for index in row.indices {
+                let size = subviews[index].sizeThatFits(.unspecified)
+                subviews[index].place(
+                    at: CGPoint(x: x, y: y + (row.height - size.height) / 2),
+                    proposal: ProposedViewSize(size)
+                )
+                x += size.width + hSpacing
+            }
+            y += row.height + vSpacing
+        }
+    }
+
+    private func rows(for subviews: Subviews, maxWidth: CGFloat) -> [Row] {
+        var rows: [Row] = []
+        var current = Row()
+
+        for index in subviews.indices {
+            let size = subviews[index].sizeThatFits(.unspecified)
+            let widthIfAppended = current.indices.isEmpty
+                ? size.width
+                : current.width + hSpacing + size.width
+
+            if !current.indices.isEmpty, widthIfAppended > maxWidth {
+                rows.append(current)
+                current = Row(indices: [index], width: size.width, height: size.height)
+            } else {
+                current.indices.append(index)
+                current.width = widthIfAppended
+                current.height = max(current.height, size.height)
+            }
+        }
+
+        if !current.indices.isEmpty { rows.append(current) }
+        return rows
+    }
+}

--- a/tvosApp/NuvioTV/Sources/UI/Search/SearchView.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Search/SearchView.swift
@@ -57,8 +57,7 @@ struct SearchView: View {
 
             VStack(alignment: .leading, spacing: 24) {
                 header
-                    .frame(width: SearchGridMetrics.cardRowWidth, alignment: .leading)
-                    .padding(.horizontal, SearchGridMetrics.gridContentInset)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .disabled(overlayRestoreResultID != nil || discoverOverlayTransitionActive)
                     .zIndex(1)
 
@@ -102,8 +101,14 @@ struct SearchView: View {
             .ignoresSafeArea(.container, edges: .bottom)
         }
         .onAppear {
-            if !viewModel.hasQuery {
-                DispatchQueue.main.async { searchBarFocused = true }
+            viewModel.reloadRecent()
+            DispatchQueue.main.async {
+                if !viewModel.hasQuery {
+                    searchBarFocused = true
+                }
+                // Netflix keeps the keyboard persistently up on the Search tab
+                // instead of popping it as a modal on first tap.
+                searchTextInputActive = true
             }
         }
         .onChange(of: focusedResultID) { newValue in
@@ -148,13 +153,7 @@ struct SearchView: View {
     // MARK: - Header + glass search bar
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            Text(L10n.string("nav_search", fallback: "Search"))
-                .font(.system(size: 46, weight: .bold))
-                .foregroundColor(.white)
-
-            searchBar
-        }
+        searchBar
     }
 
     private var searchBar: some View {
@@ -172,7 +171,7 @@ struct SearchView: View {
                 searchTextInputActive = true
             } label: {
                 Color.clear
-                    .frame(maxWidth: .infinity, minHeight: 86)
+                    .frame(maxWidth: .infinity, minHeight: 72)
                     .contentShape(Rectangle())
             }
             .buttonStyle(PosterCardButtonStyle())
@@ -187,7 +186,7 @@ struct SearchView: View {
 
                 Text(
                     viewModel.searchText.isEmpty
-                        ? L10n.string("search_placeholder", fallback: "Search movies & series")
+                        ? L10n.string("search_placeholder", fallback: "Search for movies and TV shows")
                         : viewModel.searchText
                 )
                     .font(.system(size: 30, weight: .regular))
@@ -213,9 +212,9 @@ struct SearchView: View {
             }
         }
         .padding(.horizontal, 34)
-        .frame(height: 86)
+        .frame(height: 72)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .modifier(GlassCapsule(focused: searchBarFocused || searchTextInputActive))
+        .modifier(GlassSearchBar(focused: searchBarFocused || searchTextInputActive))
     }
 
     // MARK: - Type filter
@@ -292,7 +291,8 @@ struct SearchView: View {
                         height: SearchGridMetrics.posterHeight,
                         externalFocus: $focusedResultID,
                         retainFocusAppearance: overlayRestoreResultID == item.id,
-                        onLongPress: onLongPress.map { cb in { cb(item) } }
+                        onLongPress: onLongPress.map { cb in { cb(item) } },
+                        forceShowLabels: true
                     ) {
                         overlayRestoreResultID = item.id
                         lastFocusedResultID = item.id
@@ -403,7 +403,9 @@ struct SearchView: View {
 
 // MARK: - Hidden text input
 
-private struct HiddenSearchTextField: UIViewRepresentable {
+// Internal (not private) so `NetflixSearchView` can reuse the same hidden
+// text field to fall back to tvOS's system keyboard for Siri dictation.
+struct HiddenSearchTextField: UIViewRepresentable {
     @Binding var text: String
     @Binding var isEditing: Bool
 
@@ -467,7 +469,7 @@ private struct HiddenSearchTextField: UIViewRepresentable {
     }
 }
 
-private final class HiddenSearchUITextField: UITextField {
+final class HiddenSearchUITextField: UITextField {
     override var canBecomeFocused: Bool { false }
 }
 
@@ -525,6 +527,34 @@ struct GlassCapsule: ViewModifier {
             content.glassEffect(.regular, in: Capsule())
         } else {
             content.background(.ultraThinMaterial, in: Capsule())
+        }
+    }
+}
+
+/// Full-width rounded-rectangle glass field for Search (Netflix-style), with a
+/// material fallback for tvOS < 26.
+struct GlassSearchBar: ViewModifier {
+    let focused: Bool
+
+    func body(content: Content) -> some View {
+        glassed(content)
+            .overlay(
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
+                    .stroke(
+                        focused ? AppFocusOutline.color : Color.white.opacity(0.18),
+                        lineWidth: focused ? AppFocusOutline.width : 1
+                    )
+            )
+            .scaleEffect(focused ? 1.008 : 1.0)
+            .animation(.easeOut(duration: 0.18), value: focused)
+    }
+
+    @ViewBuilder
+    private func glassed(_ content: Content) -> some View {
+        if #available(tvOS 26.0, *) {
+            content.glassEffect(.regular, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+        } else {
+            content.background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
         }
     }
 }

--- a/tvosApp/NuvioTV/Sources/UI/Settings/SettingsView.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Settings/SettingsView.swift
@@ -146,6 +146,10 @@ enum SettingsKey {
     static let posterLabels = "nuvio.tv.settings.layout.posterLabels"
     static let catalogAddonNames = "nuvio.tv.settings.layout.catalogAddonNames"
     static let discoverLocation = "nuvio.tv.settings.layout.discoverLocation"
+    /// Which Search screen the Search tab shows: `"Netflix"` (embedded
+    /// key-by-key keyboard with a title list beside the poster grid) or
+    /// `"Classic"` (system-keyboard search bar over a full-width poster grid).
+    static let searchStyle = "nuvio.tv.settings.layout.searchStyle"
     static let continueWatchingSort = "nuvio.tv.settings.layout.continueWatchingSort"
     static let upNextFromFurthestEpisode = "nuvio.tv.settings.layout.upNextFromFurthestEpisode"
     static let showUnairedNextUp = "nuvio.tv.settings.layout.showUnairedNextUp"
@@ -254,6 +258,7 @@ enum SettingsKey {
         accountSyncWatchState,
         theme, bodyColor, font, language, amoled, amoledSurfaces, reduceMotion,
         homeLayout, heroEnabled, heroCatalogs, posterLabels, catalogAddonNames, discoverLocation,
+        searchStyle,
         continueWatchingSort, upNextFromFurthestEpisode, showUnairedNextUp,
         hideUnreleased, showFullDates,
         traktConnected, traktClientID, traktClientSecret,
@@ -2014,6 +2019,7 @@ private struct LayoutDiscoverySettingsView: View {
     @AppStorage(SettingsKey.posterLabels) private var posterLabels = false
     @AppStorage(SettingsKey.catalogAddonNames) private var catalogAddonNames = true
     @AppStorage(SettingsKey.discoverLocation) private var discoverLocation = "Search"
+    @AppStorage(SettingsKey.searchStyle) private var searchStyle = "Netflix"
     @AppStorage(SettingsKey.continueWatchingSort) private var continueWatchingSort = "Default"
     @AppStorage(SettingsKey.upNextFromFurthestEpisode) private var upNextFromFurthestEpisode = true
     @AppStorage(SettingsKey.showUnairedNextUp) private var showUnairedNextUp = true
@@ -2027,6 +2033,7 @@ private struct LayoutDiscoverySettingsView: View {
     // Search is the only screen that currently hosts the full Discover surface.
     // Do not offer Home/Library as dead selections that merely hide Discover.
     private let discoverLocations = ["Search", "Off"]
+    private let searchStyles = ["Netflix", "Classic"]
     private let continueWatchingSorts = ["Default", "Recently watched", "Release order", "Next up"]
 
     var body: some View {
@@ -2145,6 +2152,22 @@ private struct LayoutDiscoverySettingsView: View {
                     fallback: "Visibility rules for discovery and continue watching"
                 )
             ) {
+                SettingsOptionRow(
+                    title: L10n.string("tvos_layout_search_style", fallback: "Search Style"),
+                    subtitle: L10n.string(
+                        "tvos_layout_search_style_subtitle",
+                        fallback: "Netflix keeps an on-screen keyboard up with a title list beside the posters; Classic uses the system keyboard over a full-width grid"
+                    ),
+                    selection: $searchStyle,
+                    options: searchStyles,
+                    accentColor: accentColor
+                )
+                .onAppear {
+                    if !searchStyles.contains(searchStyle) {
+                        searchStyle = "Netflix"
+                    }
+                }
+
                 SettingsOptionRow(
                     title: L10n.string("tvos_layout_discover_entry", fallback: "Discover Entry"),
                     subtitle: L10n.string(

--- a/tvosApp/NuvioTV/Sources/ViewModels/NetflixSearchViewModel.swift
+++ b/tvosApp/NuvioTV/Sources/ViewModels/NetflixSearchViewModel.swift
@@ -1,35 +1,20 @@
 import Foundation
 import Combine
 
-/// Content-type filter for the search screen.
-enum SearchContentType: String, CaseIterable, Identifiable {
-    case all, movie, series
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .all:
-            return L10n.string("library_type_all", fallback: "All")
-        case .movie:
-            return L10n.string("type_movies", fallback: L10n.string("type_movie", fallback: "Movies"))
-        case .series:
-            return L10n.string("type_series_plural", fallback: L10n.string("type_series", fallback: "Series"))
-        }
-    }
-}
-
+/// Netflix-style alternative to `SearchViewModel`. Same catalog search use
+/// case (`CatalogRepository.search(query:)`) and the same debounce/cache/
+/// recent-search shape, but exposes a couple of small keyboard-input helpers
+/// instead of a raw `searchText` binding, since `NetflixSearchView` builds
+/// its query from an on-screen key-by-key keyboard rather than a hidden text
+/// field.
 @MainActor
-class SearchViewModel: ObservableObject {
+class NetflixSearchViewModel: ObservableObject {
     @Published var searchText = ""
     @Published var results: [NuvioMeta] = []
     @Published var isLoading = false
     @Published var error: String?
     @Published var selectedType: SearchContentType = .all
     @Published var recentSearches: [String] = []
-    /// Last focused result card, kept here (outside the view, like
-    /// `TVHomeStore.lastFocusedCardID`) so it survives the details push and
-    /// returning restores that card instead of snapping to the first result.
-    var lastFocusedResultID: String?
 
     private let repository: CatalogRepository
     private var allResults: [NuvioMeta] = []
@@ -39,6 +24,8 @@ class SearchViewModel: ObservableObject {
     /// instantaneous without keeping stale search data on disk.
     private var cachedResults: [String: [NuvioMeta]] = [:]
     private var cacheOrder: [String] = []
+    // Same UserDefaults key as `SearchViewModel` so a user's search history
+    // carries over regardless of which search UI is wired up to navigation.
     private let recentKey = "nuvio.search.recent"
 
     init(repository: CatalogRepository = CinemetaCatalogRepository()) {
@@ -122,15 +109,28 @@ class SearchViewModel: ObservableObject {
         saveRecent()
     }
 
-    /// Re-reads the shared recent-search list. `NetflixSearchViewModel` writes
-    /// the same key, so whichever search style isn't on screen goes stale until
-    /// its view reappears.
+    /// Re-reads the shared recent-search list. `SearchViewModel` writes the
+    /// same key, so whichever search style isn't on screen goes stale until its
+    /// view reappears.
     func reloadRecent() {
         recentSearches = UserDefaults.standard.stringArray(forKey: recentKey) ?? []
     }
 
     func clear() {
         searchText = ""
+    }
+
+    // MARK: - On-screen keyboard input
+
+    /// Appends one key from the on-screen keyboard. The keyboard has no
+    /// shift state, so letters always arrive lowercase.
+    func typeCharacter(_ character: String) {
+        searchText += character
+    }
+
+    func deleteLastCharacter() {
+        guard !searchText.isEmpty else { return }
+        searchText.removeLast()
     }
 
     private func commitRecentSearch(_ term: String) {


### PR DESCRIPTION
## Summary

This PR introduces new design for searchbar to look like netflix one. It allows the user to write searched term while they see what appears on the screen.
At the same time the option to switch between the old searchview and the new one has been added to layout options in discover section.
Also the files have been moved around to meet more the ios development standarts.

**Known things to improve:**
API that would feed the side suggestions scrollview could be connected to different API to provide better suggestions. At the moment it shows only the same titles as ones that are displayed in the grid view.

**PREVIEW:**
<img width="1920" height="1080" alt="Simulator Screenshot - RBPlayer TV - 2026-08-11 at 13 51 08" src="https://github.com/user-attachments/assets/8ebaa4e9-869c-4f30-aa14-0c3d44d0eff4" />
