### PR TITLE
feat(search): use native tvOS keyboard

### DIFF
--- a/tvosApp/NuvioTV/Sources/UI/Discover/DiscoverView.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Discover/DiscoverView.swift
@@ -312,24 +312,26 @@ struct DiscoverSection: View {
 
 // MARK: - Filter dropdown
 
-/// A glass chip that opens a dropdown menu of options. Falls back to a static
-/// chip on tvOS < 17 (where `Menu` is unavailable). Shared by Discover & Library.
+/// A glass chip that opens a native SwiftUI dropdown menu. Shared by
+/// Discover and Library so filter selection stays consistent across both.
 struct FilterMenu<MenuContent: View>: View {
     let label: String
     var onFocusChange: ((Bool) -> Void)? = nil
     @ViewBuilder var menu: () -> MenuContent
-    @State private var showOptions = false
     @FocusState private var focused: Bool
 
     var body: some View {
-        Button { showOptions = true } label: { chipLabel }
-            .buttonStyle(PosterCardButtonStyle())
-            .focused($focused)
-            .focusEffectDisabledIfAvailable()
-            .scaleEffect(focused ? 1.05 : 1.0)
-            .animation(.easeOut(duration: 0.14), value: focused)
-            .confirmationDialog(label, isPresented: $showOptions, titleVisibility: .visible, actions: menu)
-            .onChange(of: focused) { _, isFocused in onFocusChange?(isFocused) }
+        Menu {
+            menu()
+        } label: {
+            chipLabel
+        }
+        .menuStyle(.borderlessButton)
+        .focused($focused)
+        .focusEffectDisabledIfAvailable()
+        .scaleEffect(focused ? 1.05 : 1.0)
+        .animation(.easeOut(duration: 0.14), value: focused)
+        .onChange(of: focused) { _, isFocused in onFocusChange?(isFocused) }
     }
 
     private var chipLabel: some View {

--- a/tvosApp/NuvioTV/Sources/UI/Search/NetflixSearchView.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Search/NetflixSearchView.swift
@@ -1,58 +1,34 @@
 import SwiftUI
 
-/// Netflix-style alternative to `SearchView`: an always-visible, embedded
-/// on-screen keyboard (no modal system keyboard) with results split into a
-/// text index on the left and a poster grid on the right, mirroring the
-/// tvOS Netflix search screen. Wired to the same `CatalogRepository` search
-/// use case as `SearchView` via `NetflixSearchViewModel`.
+/// Netflix-style alternative to `SearchView`: results split into a text index
+/// on the left and a poster grid on the right, mirroring the tvOS Netflix
+/// search screen. Wired to the same `CatalogRepository` search use case as
+/// `SearchView` via `NetflixSearchViewModel`.
 ///
-/// Reuses `PosterGridCard`, `GlassChip`, `GlassChipBackground`,
-/// `GlassCapsule`, `PosterCardButtonStyle`, `DiscoverSection`,
-/// `SearchContentType`, `ContentReleasePolicy` and the hidden-text-field
-/// dictation fallback from `SearchView.swift` rather than duplicating them.
-/// The keyboard is the one place that can't reuse `GlassChip`: it needs
-/// fixed-width keys to guarantee a no-scroll fit (see `NetflixKeyboardKey`).
+/// Text entry uses the tvOS system keyboard, embedded in the screen the way
+/// Fusion and Apple's own TV apps do it: the query header is a real, focusable
+/// `TextField`, so the system keyboard appears as part of the layout whenever
+/// the field has focus. That brings the full-size linear alphabet keyboard,
+/// the suggestions strip, and Siri dictation via a long-press on the remote's
+/// speaker/mic button with no in-app microphone button at all. Moving focus
+/// down into the filters or results resigns the field, which collapses the
+/// keyboard; moving back up to the field brings it back.
+///
+/// Reuses `PosterGridCard`, `GlassChip`, `GlassCapsule`, `GlassChipBackground`,
+/// `PosterCardButtonStyle`, `DiscoverSection`, `SearchContentType` and
+/// `ContentReleasePolicy` from `SearchView.swift` rather than duplicating them.
 private enum NetflixSearchMetrics {
     /// Sits on top of tvOS's own ~80pt overscan safe area, so this only needs
     /// to be big enough that a focused key/card's scale-up doesn't visually
     /// touch the safe-area boundary.
-    /// Match Classic Search's outer gutter so every Netflix Search surface —
-    /// not only Discover — shares the same centered content column.
+    /// Match Classic Search's outer gutter so every Netflix Search surface,
+    /// not only Discover, shares the same centered content column.
     static let pageInset: CGFloat = 36
     static let posterWidth: CGFloat = 190
     static let posterHeight: CGFloat = 285
     static let posterGap: CGFloat = 24
     static let listWidth: CGFloat = 440
     static let columnGap: CGFloat = 32
-    /// Keys are sized so all 29 of them (26 letters + 123/Space/delete) fit on
-    /// one 1080p line. `KeyboardFlowLayout` wraps to a second line rather than
-    /// scrolling if a narrower viewport can't fit them.
-    static let keyHeight: CGFloat = 54
-    static let letterKeyWidth: CGFloat = 46
-    static let toggleKeyWidth: CGFloat = 76
-    static let spaceKeyWidth: CGFloat = 116
-    static let deleteKeyWidth: CGFloat = 64
-    static let keyHGap: CGFloat = 8
-    static let keyVGap: CGFloat = 10
-}
-
-private enum NetflixKeyboardMode {
-    case letters, numbers
-
-    var keys: [String] {
-        switch self {
-        case .letters: return (UnicodeScalar("a").value...UnicodeScalar("z").value)
-            .compactMap { UnicodeScalar($0).map(String.init) }
-        case .numbers: return (0...9).map(String.init)
-        }
-    }
-
-    var toggleLabel: String {
-        switch self {
-        case .letters: return "123"
-        case .numbers: return "ABC"
-        }
-    }
 }
 
 struct NetflixSearchView: View {
@@ -61,43 +37,26 @@ struct NetflixSearchView: View {
     let onContentClick: (String, String) -> Void
     var onLongPress: ((NuvioMeta) -> Void)? = nil
 
+    /// The query header's text field. Focus here is the entry point of the
+    /// whole screen: it shows the system keyboard (with dictation) and, since
+    /// the field is a real first responder, the remote's mic button works.
+    @FocusState private var searchFieldFocused: Bool
     /// One shared focus id-space for both the text list and the poster grid,
     /// namespaced ("list:"/"grid:") so the same result can be focused in
     /// either column without the two bindings fighting over one id.
     @FocusState private var focusedItemID: String?
-    /// Keyboard focus is tracked separately from results so Search can always
-    /// restore to its predictable entry point: the `A` key.
-    @FocusState private var focusedKeyboardKeyID: String?
     @FocusState private var focusedTypeFilterID: String?
     @FocusState private var clearRecentFocused: Bool
     @FocusState private var focusedRecentSearchID: String?
-    @FocusState private var dictateFocused: Bool
-    @State private var keyboardMode: NetflixKeyboardMode = .letters
     /// Same overlay-restore dance as `SearchView`: Details is a sibling
     /// overlay (not a navigation push), so returning from it needs to
     /// re-place focus geometrically instead of snapping to the first result.
     @State private var lastFocusedItemID: String?
     @State private var shouldRestoreFocus = false
-    /// Rapid Siri Remote swipes can briefly report no focused result while the
-    /// next card is being realized. A generation lets us ignore that transient
-    /// state instead of reopening the keyboard mid-scroll.
-    @State private var itemFocusGeneration = 0
-    /// Invalidates a deferred keyboard-focus request if focus returns to a
-    /// result before the newly revealed keyboard has joined the focus tree.
-    @State private var keyboardFocusGeneration = 0
     @State private var overlayRestoreItemID: String?
     @State private var overlayRestoreGeneration = 0
     @State private var discoverOverlayTransitionActive = false
-    /// Netflix collapses its keyboard once focus enters the result surface,
-    /// giving the poster grid the full height of the screen. It returns as
-    /// soon as focus moves back out of a result.
-    @State private var keyboardVisible = true
     @Environment(\.isEnabled) private var isEnabled
-    /// True while the hidden text field is first responder, i.e. the system
-    /// keyboard (with its own Siri dictation button) is covering the screen
-    /// as a dictation fallback. The embedded keyboard has no way to hook the
-    /// remote's physical mic button itself.
-    @State private var systemDictationActive = false
     @AppStorage(SettingsKey.amoled) private var amoled = false
     @AppStorage(SettingsKey.bodyColor) private var bodyColor = SettingsBackground.charcoal.rawValue
     @AppStorage(SettingsKey.hideUnreleased) private var hideUnreleased = false
@@ -116,30 +75,6 @@ struct NetflixSearchView: View {
             VStack(alignment: .leading, spacing: 20) {
                 queryHeader
                     .disabled(overlayRestoreItemID != nil || discoverOverlayTransitionActive)
-                ViewThatFits(in: .horizontal) {
-                    // Prefer the centered Netflix-style single row.
-                    HStack(spacing: 0) {
-                        Spacer(minLength: 0)
-                        keyboardPanel.frame(width: keyboardContentWidth, alignment: .leading)
-                        Spacer(minLength: 0)
-                    }
-                    // When it cannot fit, constrain the layout so it wraps its
-                    // keys rather than retaining an oversized ideal width.
-                    keyboardPanel
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                // Keep the keyboard mounted even while collapsed. Removing it
-                // made a synchronous focus request target a view that did not
-                // exist yet, allowing the adaptive tab sidebar to take focus.
-                .frame(height: keyboardVisible ? nil : 1, alignment: .top)
-                // tvOS treats alpha-zero controls as unfocusable. Keep a tiny
-                // non-zero alpha while collapsed: it is visually hidden, still
-                // occupies no useful layout height, and remains an Up target.
-                .opacity(keyboardVisible ? 1 : 0.01)
-                .disabled(
-                    overlayRestoreItemID != nil ||
-                    discoverOverlayTransitionActive
-                )
 
                 if viewModel.hasQuery {
                     typeFilterRow
@@ -154,24 +89,6 @@ struct NetflixSearchView: View {
                         DiscoverSection(
                             onContentClick: onContentClick,
                             onLongPress: onLongPress,
-                            onCardFocus: {
-                                keyboardFocusGeneration &+= 1
-                                withAnimation(.easeInOut(duration: 0.22)) {
-                                    keyboardVisible = false
-                                }
-                            },
-                            onFilterFocus: {
-                                showKeyboard()
-                            },
-                            onFocusExit: {
-                                // A recent-search chip is directly above Discover.
-                                // If focus moved there, keep it there rather than
-                                // stealing it back for the keyboard's `A` key.
-                                guard isEnabled,
-                                      !discoverOverlayTransitionActive,
-                                      focusedRecentSearchID == nil else { return }
-                                focusKeyboardOnA()
-                            },
                             parentTransitionActive: $discoverOverlayTransitionActive
                         )
                             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -191,49 +108,20 @@ struct NetflixSearchView: View {
             .padding(.horizontal, NetflixSearchMetrics.pageInset)
             .padding(.top, 16)
             .ignoresSafeArea(.container, edges: .bottom)
-            .animation(.easeInOut(duration: 0.22), value: keyboardVisible)
-
-            // Off-screen; becomes first responder only for the dictation
-            // fallback (see `dictateButton`). Reused from `SearchView.swift`.
-            HiddenSearchTextField(text: $viewModel.searchText, isEditing: $systemDictationActive)
-                .frame(width: 1, height: 1)
-                .offset(x: -4_000)
-                .allowsHitTesting(false)
         }
         .onAppear {
             viewModel.reloadRecent()
-            focusKeyboardOnA()
+            focusSearchField()
         }
         .onExitCommand(perform: canHandleExitCommand ? handleExitCommand : nil)
         .onChange(of: focusedItemID) { _, newValue in
-            itemFocusGeneration &+= 1
-            let generation = itemFocusGeneration
             if let newValue {
-                keyboardFocusGeneration &+= 1
-                withAnimation(.easeInOut(duration: 0.22)) {
-                    // Collapse as soon as the first result row receives focus;
-                    // the nearly invisible mounted keyboard remains the Up
-                    // target, so focus can still return without reaching the
-                    // tab sidebar.
-                    keyboardVisible = false
-                }
                 lastFocusedItemID = newValue
                 shouldRestoreFocus = false
                 if isEnabled, newValue == overlayRestoreItemID { overlayRestoreItemID = nil }
             } else if lastFocusedItemID != nil {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.14) {
-                    guard itemFocusGeneration == generation,
-                          focusedItemID == nil,
-                          focusedTypeFilterID == nil,
-                          viewModel.hasQuery,
-                          isEnabled else { return }
-                    focusKeyboardOnA()
-                    shouldRestoreFocus = true
-                }
+                shouldRestoreFocus = true
             }
-        }
-        .onChange(of: focusedTypeFilterID) { _, newValue in
-            if newValue != nil { showKeyboard() }
         }
         .onChange(of: isEnabled) { _, enabled in
             if !enabled {
@@ -260,248 +148,36 @@ struct NetflixSearchView: View {
         }
     }
 
-    // MARK: - Header: query readout + dictate
+    // MARK: - Header: query field (system keyboard + dictation)
 
+    /// A real text field in a glass capsule. While it has focus the tvOS
+    /// system keyboard is on screen with its suggestions strip, and a
+    /// long-press on the Siri Remote's speaker button starts dictation.
     private var queryHeader: some View {
-        ZStack(alignment: .trailing) {
-            queryReadout
-                .frame(maxWidth: .infinity)
-            dictateButton
-        }
-    }
-
-    private var queryReadout: some View {
         HStack(spacing: 16) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: 26, weight: .semibold))
+                .font(.system(size: 30, weight: .semibold))
                 .foregroundColor(.white.opacity(0.7))
-            Text(
-                viewModel.searchText.isEmpty
-                    ? L10n.string("search_placeholder", fallback: "Search for movies and TV shows")
-                    : viewModel.searchText
+
+            TextField(
+                L10n.string("search_placeholder", fallback: "Search for movies and TV shows"),
+                text: $viewModel.searchText
             )
-                                .font(.system(size: 26, weight: .medium))
-                .foregroundColor(viewModel.searchText.isEmpty ? .white.opacity(0.45) : .white)
-                .lineLimit(1)
+            .font(.system(size: 30, weight: .medium))
+            .foregroundColor(.white)
+            .lineLimit(1)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .focused($searchFieldFocused)
         }
         .padding(.horizontal, 26)
-        .frame(height: 58)
-        .frame(maxWidth: 720, alignment: .leading)
-        .modifier(GlassCapsule(focused: false))
-    }
-
-    private var dictateButton: some View {
-        Button {
-            systemDictationActive = true
-        } label: {
-            Image(systemName: "mic.fill")
-                .font(.system(size: 20, weight: .semibold))
-                .padding(8)
-                .background(Circle().fill(Color.white.opacity(dictateFocused ? 1 : 0.16)))
-                .foregroundColor(dictateFocused ? .black : .white.opacity(0.75))
-        }
-        .buttonStyle(PosterCardButtonStyle())
-        .focused($dictateFocused)
+        .frame(height: 72)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .modifier(GlassCapsule(focused: searchFieldFocused))
+        // The capsule's own focus styling (border + brightening) is the only
+        // indicator we want; the system's default highlight would draw a
+        // white pill over it.
         .focusEffectDisabledIfAvailable()
-        .scaleEffect(dictateFocused ? 1.05 : 1.0)
-        .animation(.easeOut(duration: 0.14), value: dictateFocused)
-    }
-
-    // MARK: - Embedded keyboard
-
-    private var keyboard: some View {
-        KeyboardFlowLayout(
-            hSpacing: NetflixSearchMetrics.keyHGap,
-            vSpacing: NetflixSearchMetrics.keyVGap
-        ) {
-            NetflixKeyboardKey(
-                label: keyboardMode.toggleLabel,
-                width: NetflixSearchMetrics.toggleKeyWidth,
-                externalFocus: $focusedKeyboardKeyID,
-                focusID: "keyboard:mode",
-                onMove: handleKeyboardMove
-            ) {
-                keyboardMode = keyboardMode == .letters ? .numbers : .letters
-            }
-
-            NetflixKeyboardKey(
-                label: L10n.string("search_keyboard_space", fallback: "Space"),
-                width: NetflixSearchMetrics.spaceKeyWidth,
-                externalFocus: $focusedKeyboardKeyID,
-                focusID: "keyboard:space",
-                onMove: handleKeyboardMove
-            ) {
-                viewModel.typeCharacter(" ")
-            }
-
-            ForEach(keyboardMode.keys, id: \.self) { key in
-                NetflixKeyboardKey(
-                    label: key,
-                    width: NetflixSearchMetrics.letterKeyWidth,
-                    externalFocus: $focusedKeyboardKeyID,
-                    focusID: "keyboard:\(key)",
-                    onMove: handleKeyboardMove
-                ) {
-                    viewModel.typeCharacter(key)
-                }
-            }
-
-            NetflixKeyboardKey(
-                label: "",
-                systemImage: "delete.left",
-                width: NetflixSearchMetrics.deleteKeyWidth,
-                externalFocus: $focusedKeyboardKeyID,
-                focusID: "keyboard:delete",
-                onMove: handleKeyboardMove
-            ) {
-                viewModel.deleteLastCharacter()
-            }
-        }
-        .focusSection()
-        .defaultFocusIfAvailable($focusedKeyboardKeyID, "keyboard:a")
-    }
-
-    private var keyboardPanel: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            keyboard
-            Rectangle()
-                .fill(Color.white.opacity(0.14))
-                .frame(maxWidth: .infinity)
-                .frame(height: 1)
-        }
-    }
-
-    /// The divider is intentionally the keyboard's content width, rather than
-    /// the full page width, so its right edge lines up with Delete.
-    private var keyboardContentWidth: CGFloat {
-        let letterCount = CGFloat(keyboardMode.keys.count)
-        let keyWidths = NetflixSearchMetrics.toggleKeyWidth
-            + NetflixSearchMetrics.spaceKeyWidth
-            + letterCount * NetflixSearchMetrics.letterKeyWidth
-            + NetflixSearchMetrics.deleteKeyWidth
-        let gaps = CGFloat(keyboardMode.keys.count + 2) * NetflixSearchMetrics.keyHGap
-        return keyWidths + gaps
-    }
-
-    private var canHandleExitCommand: Bool {
-        guard isEnabled,
-              overlayRestoreItemID == nil,
-              !discoverOverlayTransitionActive else { return false }
-        return focusedItemID != nil || focusedTypeFilterID != nil || (!keyboardVisible && (viewModel.hasQuery || showDiscover))
-    }
-
-    private func handleExitCommand() {
-        focusKeyboardOnA()
-    }
-
-    /// Results hide the keyboard to make room for the grid. Once focus moves
-    /// back above its first poster, or the user presses the Back button from
-    /// a card/filter, bring it back and put the cursor at the 'A' key.
-    private func focusKeyboardOnA() {
-        keyboardFocusGeneration &+= 1
-        let generation = keyboardFocusGeneration
-        keyboardMode = .letters
-        focusedItemID = nil
-        focusedTypeFilterID = nil
-        withAnimation(.easeInOut(duration: 0.22)) {
-            keyboardVisible = true
-            focusedKeyboardKeyID = "keyboard:a"
-        }
-        DispatchQueue.main.async {
-            guard keyboardFocusGeneration == generation,
-                  keyboardVisible,
-                  isEnabled else { return }
-            focusedItemID = nil
-            focusedTypeFilterID = nil
-            focusedKeyboardKeyID = "keyboard:a"
-        }
-    }
-
-    /// tvOS can continue processing the same Up press after `onMoveCommand`
-    /// returns. Hold the source card through that pass, reveal the keyboard,
-    /// then land on the All filter as the intermediate focus stop.
-    private func transferFirstRowFocusToAllFilter() {
-        guard let sourceFocusID = focusedItemID else { return }
-
-        keyboardFocusGeneration &+= 1
-        let generation = keyboardFocusGeneration
-        keyboardMode = .letters
-        focusedKeyboardKeyID = nil
-        withAnimation(.easeInOut(duration: 0.22)) {
-            keyboardVisible = true
-        }
-
-        // Claim the current card again so this Up press cannot also open the
-        // adaptive tab sidebar. This mirrors the app's grid-hero focus guard.
-        focusedItemID = sourceFocusID
-        DispatchQueue.main.async {
-            guard keyboardFocusGeneration == generation,
-                  keyboardVisible,
-                  isEnabled else { return }
-            focusedItemID = sourceFocusID
-            DispatchQueue.main.async {
-                guard keyboardVisible,
-                      isEnabled,
-                      focusedItemID == sourceFocusID else { return }
-                focusedTypeFilterID = "type:all"
-            }
-        }
-    }
-
-    /// Claim the filter for the remainder of its Up press, then enter the
-    /// keyboard on the next focus pass so the adaptive sidebar cannot win.
-    private func transferTypeFilterFocusToKeyboard() {
-        guard let sourceFocusID = focusedTypeFilterID else { return }
-
-        keyboardFocusGeneration &+= 1
-        let generation = keyboardFocusGeneration
-        keyboardMode = .letters
-        focusedKeyboardKeyID = nil
-        withAnimation(.easeInOut(duration: 0.22)) {
-            keyboardVisible = true
-        }
-
-        focusedTypeFilterID = sourceFocusID
-        DispatchQueue.main.async {
-            guard keyboardFocusGeneration == generation,
-                  keyboardVisible,
-                  isEnabled else { return }
-            focusedTypeFilterID = sourceFocusID
-            DispatchQueue.main.async {
-                guard keyboardVisible,
-                      isEnabled,
-                      focusedTypeFilterID == sourceFocusID else { return }
-                focusedKeyboardKeyID = "keyboard:a"
-            }
-        }
-    }
-
-    /// Keep the active key claimed for the rest of its Down press, then move
-    /// directly to the first poster without stopping on the type filters.
-    private func transferKeyboardFocusToFirstCard() {
-        guard let targetFocusID = visibleResults.first.map({ "grid:\($0.id)" }) else { return }
-
-        keyboardFocusGeneration &+= 1
-        let generation = keyboardFocusGeneration
-        // Claim the target immediately, then once more after the focus engine
-        // processes the same Down command. This skips the type-filter row.
-        focusedItemID = targetFocusID
-        DispatchQueue.main.async {
-            guard keyboardFocusGeneration == generation,
-                  isEnabled else { return }
-            focusedItemID = targetFocusID
-        }
-    }
-
-    private func handleKeyboardMove(_ direction: MoveCommandDirection) {
-        guard direction == .down else { return }
-        transferKeyboardFocusToFirstCard()
-    }
-
-    /// Filter controls remain focused while the keyboard comes back into view;
-    /// only leaving Discover altogether moves focus to its `A` entry key.
-    private func showKeyboard() {
-        withAnimation(.easeInOut(duration: 0.22)) { keyboardVisible = true }
     }
 
     // MARK: - Type filter
@@ -526,10 +202,6 @@ struct NetflixSearchView: View {
                     .font(.system(size: 22, weight: .medium))
                     .foregroundColor(.white.opacity(0.5))
             }
-        }
-        .onMoveCommand { direction in
-            guard direction == .up, focusedTypeFilterID != nil else { return }
-            transferTypeFilterFocusToKeyboard()
         }
     }
 
@@ -628,11 +300,7 @@ struct NetflixSearchView: View {
                         focusValue: focusID,
                         retainFocusAppearance: overlayRestoreItemID == focusID,
                         onLongPress: onLongPress.map { cb in { cb(item) } },
-                        forceShowLabels: true,
-                        onMove: index < gridColumns.count ? { direction in
-                            guard direction == .up else { return }
-                            transferFirstRowFocusToAllFilter()
-                        } : nil
+                        forceShowLabels: true
                     ) {
                         overlayRestoreItemID = focusID
                         lastFocusedItemID = focusID
@@ -651,18 +319,6 @@ struct NetflixSearchView: View {
         .focusSection()
     }
 
-    /// List row the results area should focus when it (re)gains focus: the
-    /// row the user left on when armed and still present, else the first one.
-    private var defaultItemFocusID: String? {
-        if shouldRestoreFocus,
-           let saved = lastFocusedItemID,
-           saved.hasPrefix("list:"),
-           visibleResults.contains(where: { "list:\($0.id)" == saved }) {
-            return saved
-        }
-        return visibleResults.first.map { "list:\($0.id)" }
-    }
-
     /// A 1080p Apple TV has room for six of these posters beside the text
     /// index. Keeping that count explicit avoids `LazyVGrid` choosing a
     /// smaller intrinsic width and leaving an unused sixth slot at the right.
@@ -677,12 +333,16 @@ struct NetflixSearchView: View {
         )
     }
 
-    private func isFirstGridRowFocusID(_ focusID: String) -> Bool {
-        guard focusID.hasPrefix("grid:"),
-              let index = visibleResults.firstIndex(where: { "grid:\($0.id)" == focusID }) else {
-            return false
+    /// List row the results area should focus when it (re)gains focus: the
+    /// row the user left on when armed and still present, else the first one.
+    private var defaultItemFocusID: String? {
+        if shouldRestoreFocus,
+           let saved = lastFocusedItemID,
+           saved.hasPrefix("list:"),
+           visibleResults.contains(where: { "list:\($0.id)" == saved }) {
+            return saved
         }
-        return index < gridColumns.count
+        return visibleResults.first.map { "list:\($0.id)" }
     }
 
     // MARK: Recent searches (shown above Discover when idle)
@@ -762,109 +422,35 @@ struct NetflixSearchView: View {
         }
         .frame(maxWidth: 700)
     }
-}
 
-// MARK: - Keyboard key
+    // MARK: - Focus helpers
 
-/// Fixed-width keyboard key. `GlassChip` sizes itself from its text plus 30pt
-/// of horizontal padding, which is far too wide for single characters, so keys
-/// take an explicit width instead.
-private struct NetflixKeyboardKey: View {
-    let label: String
-    var systemImage: String? = nil
-    let width: CGFloat
-    var externalFocus: FocusState<String?>.Binding? = nil
-    var focusID: String = ""
-    let onMove: (MoveCommandDirection) -> Void
-    let action: () -> Void
-    @FocusState private var focused: Bool
-
-    var body: some View {
-        Button(action: action) {
-            Group {
-                if let systemImage {
-                    Image(systemName: systemImage)
-                        .font(.system(size: 22, weight: .semibold))
-                } else {
-                    Text(label)
-                        .font(.system(size: 24, weight: .semibold))
-                }
-            }
-            .foregroundColor(focused ? .black : .white.opacity(0.85))
-            .frame(width: width, height: NetflixSearchMetrics.keyHeight)
-            .modifier(GlassChipBackground(filled: focused))
-        }
-        .buttonStyle(PosterCardButtonStyle())
-        .focused($focused)
-        .modifier(ExternalFocusBinding(binding: externalFocus, id: focusID))
-        .focusEffectDisabledIfAvailable()
-        .onMoveCommand(perform: onMove)
-        .scaleEffect(focused ? 1.08 : 1.0)
-        .animation(.easeOut(duration: 0.14), value: focused)
-    }
-}
-
-// MARK: - Wrapping keyboard layout
-
-/// Lays keys out left-to-right, wrapping onto another line when the next key
-/// wouldn't fit. The keyboard must never scroll — every key has to be visible
-/// and directly reachable — so overflow becomes a second row instead.
-private struct KeyboardFlowLayout: Layout {
-    let hSpacing: CGFloat
-    let vSpacing: CGFloat
-
-    private struct Row {
-        var indices: [Int] = []
-        var width: CGFloat = 0
-        var height: CGFloat = 0
-    }
-
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        let maxWidth = proposal.width ?? .infinity
-        let rows = rows(for: subviews, maxWidth: maxWidth)
-        let height = rows.reduce(0) { $0 + $1.height }
-            + vSpacing * CGFloat(max(0, rows.count - 1))
-        let widest = rows.map(\.width).max() ?? 0
-        return CGSize(width: maxWidth.isFinite ? maxWidth : widest, height: height)
-    }
-
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        var y = bounds.minY
-        for row in rows(for: subviews, maxWidth: bounds.width) {
-            var x = bounds.minX
-            for index in row.indices {
-                let size = subviews[index].sizeThatFits(.unspecified)
-                subviews[index].place(
-                    at: CGPoint(x: x, y: y + (row.height - size.height) / 2),
-                    proposal: ProposedViewSize(size)
-                )
-                x += size.width + hSpacing
-            }
-            y += row.height + vSpacing
-        }
-    }
-
-    private func rows(for subviews: Subviews, maxWidth: CGFloat) -> [Row] {
-        var rows: [Row] = []
-        var current = Row()
-
-        for index in subviews.indices {
-            let size = subviews[index].sizeThatFits(.unspecified)
-            let widthIfAppended = current.indices.isEmpty
-                ? size.width
-                : current.width + hSpacing + size.width
-
-            if !current.indices.isEmpty, widthIfAppended > maxWidth {
-                rows.append(current)
-                current = Row(indices: [index], width: size.width, height: size.height)
-            } else {
-                current.indices.append(index)
-                current.width = widthIfAppended
-                current.height = max(current.height, size.height)
+    /// Makes the query field the screen's entry point whenever the tab
+    /// appears: the system keyboard is up immediately, so dictation (hold the
+    /// remote's mic button) and typing are available without any first tap.
+    /// The request is retried because focus can only land on a view that has
+    /// joined the window's focus tree.
+    private func focusSearchField() {
+        guard isEnabled, overlayRestoreItemID == nil, !discoverOverlayTransitionActive else { return }
+        searchFieldFocused = true
+        DispatchQueue.main.async {
+            if focusedItemID == nil, focusedTypeFilterID == nil,
+               focusedRecentSearchID == nil, !clearRecentFocused {
+                searchFieldFocused = true
             }
         }
+    }
 
-        if !current.indices.isEmpty { rows.append(current) }
-        return rows
+    /// Back button from the results returns to the query field, matching the
+    /// old behavior where Menu re-opened the on-screen keyboard.
+    private var canHandleExitCommand: Bool {
+        guard isEnabled,
+              overlayRestoreItemID == nil,
+              !discoverOverlayTransitionActive else { return false }
+        return focusedItemID != nil || focusedTypeFilterID != nil
+    }
+
+    private func handleExitCommand() {
+        focusSearchField()
     }
 }

--- a/tvosApp/NuvioTV/Sources/UI/Search/NetflixSearchView.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Search/NetflixSearchView.swift
@@ -5,14 +5,11 @@ import SwiftUI
 /// search screen. Wired to the same `CatalogRepository` search use case as
 /// `SearchView` via `NetflixSearchViewModel`.
 ///
-/// Text entry uses the tvOS system keyboard, embedded in the screen the way
-/// Fusion and Apple's own TV apps do it: the query header is a real, focusable
-/// `TextField`, so the system keyboard appears as part of the layout whenever
-/// the field has focus. That brings the full-size linear alphabet keyboard,
-/// the suggestions strip, and Siri dictation via a long-press on the remote's
-/// speaker/mic button with no in-app microphone button at all. Moving focus
-/// down into the filters or results resigns the field, which collapses the
-/// keyboard; moving back up to the field brings it back.
+/// Text entry uses a real tvOS `TextField` in the search layout. Its native
+/// editor stays in the focus hierarchy while the visible text is rendered by
+/// the app's glass chrome, preventing tvOS's default white focus platter from
+/// covering the design. This preserves the full-size linear alphabet keyboard,
+/// suggestions strip, Siri dictation, and native focus transitions.
 ///
 /// Reuses `PosterGridCard`, `GlassChip`, `GlassCapsule`, `GlassChipBackground`,
 /// `PosterCardButtonStyle`, `DiscoverSection`, `SearchContentType` and
@@ -37,9 +34,8 @@ struct NetflixSearchView: View {
     let onContentClick: (String, String) -> Void
     var onLongPress: ((NuvioMeta) -> Void)? = nil
 
-    /// The query header's text field. Focus here is the entry point of the
-    /// whole screen: it shows the system keyboard (with dictation) and, since
-    /// the field is a real first responder, the remote's mic button works.
+    /// The query field is the screen's entry point. Its native editor remains
+    /// focusable so tvOS owns keyboard presentation and Siri dictation.
     @FocusState private var searchFieldFocused: Bool
     /// One shared focus id-space for both the text list and the poster grid,
     /// namespaced ("list:"/"grid:") so the same result can be focused in
@@ -111,7 +107,9 @@ struct NetflixSearchView: View {
         }
         .onAppear {
             viewModel.reloadRecent()
-            focusSearchField()
+        }
+        .onDisappear {
+            searchFieldFocused = false
         }
         .onExitCommand(perform: canHandleExitCommand ? handleExitCommand : nil)
         .onChange(of: focusedItemID) { _, newValue in
@@ -150,34 +148,48 @@ struct NetflixSearchView: View {
 
     // MARK: - Header: query field (system keyboard + dictation)
 
-    /// A real text field in a glass capsule. While it has focus the tvOS
-    /// system keyboard is on screen with its suggestions strip, and a
-    /// long-press on the Siri Remote's speaker button starts dictation.
+    /// Keeps the real tvOS editor in the focus hierarchy while rendering the
+    /// query with the same glass treatment used by the rest of Search. The
+    /// editor is nearly transparent rather than off-screen, so the native
+    /// keyboard is attached directly to this search surface.
     private var queryHeader: some View {
-        HStack(spacing: 16) {
-            Image(systemName: "magnifyingglass")
-                .font(.system(size: 30, weight: .semibold))
-                .foregroundColor(.white.opacity(0.7))
-
+        ZStack(alignment: .leading) {
             TextField(
-                L10n.string("search_placeholder", fallback: "Search for movies and TV shows"),
+                "",
                 text: $viewModel.searchText
             )
-            .font(.system(size: 30, weight: .medium))
-            .foregroundColor(.white)
-            .lineLimit(1)
+            .textFieldStyle(.plain)
+            .focused($searchFieldFocused)
+            .focusEffectDisabledIfAvailable()
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled()
-            .focused($searchFieldFocused)
+            .frame(maxWidth: .infinity, minHeight: 72)
+            // tvOS's native editor paints a white focus platter even when
+            // the app supplies its own background. Keep the editor alive and
+            // focusable, but let the glass overlay below own the appearance.
+            .opacity(0.02)
+
+            HStack(spacing: 16) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.7))
+
+                Text(
+                    viewModel.searchText.isEmpty
+                        ? L10n.string("search_placeholder", fallback: "Search for movies and TV shows")
+                        : viewModel.searchText
+                )
+                .font(.system(size: 30, weight: .medium))
+                .foregroundColor(viewModel.searchText.isEmpty ? .white.opacity(0.45) : .white)
+                .lineLimit(1)
+                .allowsHitTesting(false)
+            }
+            .allowsHitTesting(false)
         }
         .padding(.horizontal, 26)
         .frame(height: 72)
         .frame(maxWidth: .infinity, alignment: .leading)
         .modifier(GlassCapsule(focused: searchFieldFocused))
-        // The capsule's own focus styling (border + brightening) is the only
-        // indicator we want; the system's default highlight would draw a
-        // white pill over it.
-        .focusEffectDisabledIfAvailable()
     }
 
     // MARK: - Type filter
@@ -425,24 +437,12 @@ struct NetflixSearchView: View {
 
     // MARK: - Focus helpers
 
-    /// Makes the query field the screen's entry point whenever the tab
-    /// appears: the system keyboard is up immediately, so dictation (hold the
-    /// remote's mic button) and typing are available without any first tap.
-    /// The request is retried because focus can only land on a view that has
-    /// joined the window's focus tree.
+    /// Back button from the results returns to the query field, matching the
+    /// old behavior where Menu re-opened the on-screen keyboard.
     private func focusSearchField() {
         guard isEnabled, overlayRestoreItemID == nil, !discoverOverlayTransitionActive else { return }
         searchFieldFocused = true
-        DispatchQueue.main.async {
-            if focusedItemID == nil, focusedTypeFilterID == nil,
-               focusedRecentSearchID == nil, !clearRecentFocused {
-                searchFieldFocused = true
-            }
-        }
     }
-
-    /// Back button from the results returns to the query field, matching the
-    /// old behavior where Menu re-opened the on-screen keyboard.
     private var canHandleExitCommand: Bool {
         guard isEnabled,
               overlayRestoreItemID == nil,

--- a/tvosApp/NuvioTV/Sources/UI/Search/SearchView.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Search/SearchView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 /// Same poster geometry as the See All catalog and Grid Home. Seven columns fit
 /// only because of `pageInset` — the old 80pt inset left room for six.
@@ -43,7 +42,6 @@ struct SearchView: View {
     @State private var overlayRestoreGeneration = 0
     @State private var discoverOverlayTransitionActive = false
     @Environment(\.isEnabled) private var isEnabled
-    @State private var searchTextInputActive = false
     @AppStorage(SettingsKey.amoled) private var amoled = false
     @AppStorage(SettingsKey.bodyColor) private var bodyColor = SettingsBackground.charcoal.rawValue
     @AppStorage(SettingsKey.hideUnreleased) private var hideUnreleased = false
@@ -107,6 +105,9 @@ struct SearchView: View {
         .onAppear {
             viewModel.reloadRecent()
         }
+        .onDisappear {
+            searchBarFocused = false
+        }
         .onChange(of: focusedResultID) { _, newValue in
             if let newValue {
                 restoreArmTask?.cancel()
@@ -166,27 +167,24 @@ struct SearchView: View {
         searchBar
     }
 
+    /// Uses a real tvOS editor so the system keyboard and Siri dictation stay
+    /// attached to the search surface. The editor is nearly transparent while
+    /// the app-owned glass content preserves the existing visual design.
     private var searchBar: some View {
         ZStack(alignment: .leading) {
-            HiddenSearchTextField(
-                text: $viewModel.searchText,
-                isEditing: $searchTextInputActive,
+            TextField(
+                "",
+                text: $viewModel.searchText
             )
-            .frame(width: 1, height: 1)
-            .offset(x: -4_000)
-            .allowsHitTesting(false)
-
-            Button {
-                searchBarFocused = true
-                searchTextInputActive = true
-            } label: {
-                Color.clear
-                    .frame(maxWidth: .infinity, minHeight: 72)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(PosterCardButtonStyle())
+            .textFieldStyle(.plain)
             .focused($searchBarFocused)
             .focusEffectDisabledIfAvailable()
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .frame(maxWidth: .infinity, minHeight: 72)
+            // Keep the native editor focusable without allowing tvOS's white
+            // focus platter to cover the custom glass treatment.
+            .opacity(0.02)
 
             // Glass overlay: magnifier + typed text / placeholder + clear.
             HStack(spacing: 18) {
@@ -210,7 +208,6 @@ struct SearchView: View {
                     Button {
                         viewModel.clear()
                         searchBarFocused = true
-                        searchTextInputActive = false
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                             .font(.system(size: 30))
@@ -224,7 +221,7 @@ struct SearchView: View {
         .padding(.horizontal, 34)
         .frame(height: 72)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .modifier(GlassCapsule(focused: searchBarFocused || searchTextInputActive))
+        .modifier(GlassCapsule(focused: searchBarFocused))
     }
 
     // MARK: - Type filter
@@ -410,78 +407,6 @@ struct SearchView: View {
 }
 
 // MARK: - Result card
-
-// MARK: - Hidden text input
-
-// Internal (not private) so `NetflixSearchView` can reuse the same hidden
-// text field to fall back to tvOS's system keyboard for Siri dictation.
-struct HiddenSearchTextField: UIViewRepresentable {
-    @Binding var text: String
-    @Binding var isEditing: Bool
-
-    func makeUIView(context: Context) -> HiddenSearchUITextField {
-        let textField = HiddenSearchUITextField(frame: .zero)
-        textField.delegate = context.coordinator
-        textField.backgroundColor = .clear
-        textField.textColor = .clear
-        textField.tintColor = .clear
-        textField.returnKeyType = .search
-        textField.keyboardAppearance = .dark
-        textField.autocorrectionType = .no
-        textField.addTarget(
-            context.coordinator,
-            action: #selector(Coordinator.textDidChange(_:)),
-            for: .editingChanged
-        )
-        return textField
-    }
-
-    func updateUIView(_ uiView: HiddenSearchUITextField, context: Context) {
-        if uiView.text != text {
-            uiView.text = text
-        }
-
-        if isEditing && !uiView.isFirstResponder {
-            DispatchQueue.main.async {
-                uiView.becomeFirstResponder()
-            }
-        } else if !isEditing && uiView.isFirstResponder {
-            uiView.resignFirstResponder()
-        }
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text, isEditing: $isEditing)
-    }
-
-    final class Coordinator: NSObject, UITextFieldDelegate {
-        private let text: Binding<String>
-        private let isEditing: Binding<Bool>
-
-        init(text: Binding<String>, isEditing: Binding<Bool>) {
-            self.text = text
-            self.isEditing = isEditing
-        }
-
-        @objc func textDidChange(_ sender: UITextField) {
-            text.wrappedValue = sender.text ?? ""
-        }
-
-        func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-            isEditing.wrappedValue = false
-            textField.resignFirstResponder()
-            return true
-        }
-
-        func textFieldDidEndEditing(_ textField: UITextField) {
-            isEditing.wrappedValue = false
-        }
-    }
-}
-
-final class HiddenSearchUITextField: UITextField {
-    override var canBecomeFocused: Bool { false }
-}
 
 // MARK: - Glass components
 

--- a/tvosApp/NuvioTV/Sources/ViewModels/NetflixSearchViewModel.swift
+++ b/tvosApp/NuvioTV/Sources/ViewModels/NetflixSearchViewModel.swift
@@ -1,12 +1,10 @@
 import Foundation
 import Combine
 
-/// Netflix-style alternative to `SearchViewModel`. Same catalog search use
-/// case (`CatalogRepository.search(query:)`) and the same debounce/cache/
-/// recent-search shape, but exposes a couple of small keyboard-input helpers
-/// instead of a raw `searchText` binding, since `NetflixSearchView` builds
-/// its query from an on-screen key-by-key keyboard rather than a hidden text
-/// field.
+/// Netflix-style alternative to `SearchViewModel`. It uses the same catalog
+/// search use case (`CatalogRepository.search(query:)`) and the same
+/// debounce/cache/recent-search behavior while keeping the Netflix results
+/// presentation independent until the two search styles are consolidated.
 @MainActor
 class NetflixSearchViewModel: ObservableObject {
     @Published var searchText = ""
@@ -194,19 +192,6 @@ class NetflixSearchViewModel: ObservableObject {
 
     func clear() {
         searchText = ""
-    }
-
-    // MARK: - On-screen keyboard input
-
-    /// Appends one key from the on-screen keyboard. The keyboard has no
-    /// shift state, so letters always arrive lowercase.
-    func typeCharacter(_ character: String) {
-        searchText += character
-    }
-
-    func deleteLastCharacter() {
-        guard !searchText.isEmpty else { return }
-        searchText.removeLast()
     }
 
     private func commitRecentSearch(_ term: String) {


### PR DESCRIPTION
## Summary

- Replace the custom/hidden UIKit search input with real native tvOS `TextField` controls in both Search styles.
- Keep the existing glass search styling while suppressing tvOS's default white focus platter.
- Preserve the Netflix-style results split, recent searches, type filters, result focus restoration, and details-overlay behavior.
- Remove obsolete custom-keyboard helpers from `NetflixSearchViewModel`.

## Why the native keyboard

The native tvOS keyboard was chosen instead of rebuilding the keyboard in SwiftUI because it is the more intuitive Apple TV experience:

- It uses the keyboard layout users already know from tvOS.
- Siri Remote focus movement, key navigation, editing, suggestions, and dictation remain system-managed.
- Siri Remote hold-to-talk works through the focused search field without adding a separate in-app microphone button.
- Accessibility, localization, keyboard changes, and future tvOS improvements come from the system instead of requiring ongoing custom-keyboard maintenance.
- A custom keyboard would require manually reproducing key layout, focus transitions, text editing, deletion, suggestions, and dictation behavior while being less familiar to users.

The app still owns the visual presentation: the real text field remains focusable and connected to the search view model, while the surrounding glass styling hides the default focus platter and keeps the search page consistent with the rest of the app.

## Verification

- `xcodebuild ... build` succeeded for Apple TV 4K (3rd generation) simulator, tvOS 27.0.
- `xcodebuild ... test` succeeded: 279 tests, 0 failures.
- The built app was installed and launched on the Apple TV simulator.
- Manual simulator verification confirmed the search interaction works.
- Physical Apple TV dictation verification remains recommended before merge.

## Imagery
<img width="1700" height="978" alt="CleanShot 2026-09-06 at 11 05 40@2x" src="https://github.com/user-attachments/assets/fd1f8c1e-47b6-4af2-9fb4-08aa2c27cec5" />
<img width="1698" height="978" alt="CleanShot 2026-09-06 at 11 06 04@2x" src="https://github.com/user-attachments/assets/6256bb2c-4534-4f0d-b773-7278f7a0bb1a" />

Closes #55