### PR TITLE
feat(player): add native subtitle selector

### DIFF
--- a/tvosApp/NuvioTV/Sources/UI/Player/PlayerControls.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Player/PlayerControls.swift
@@ -6,6 +6,7 @@ private enum PlayerControlFocus: Hashable {
     case pip
     case episodes
     case sources
+    case subtitles
     case settings
     case timeline
 }
@@ -144,8 +145,48 @@ struct PlayerControls: View {
         if viewModel.isPictureInPictureSupported && playerShowPiP { order.append(.pip) }
         if viewModel.canShowEpisodesPanel && playerShowEpisodes { order.append(.episodes) }
         if viewModel.canShowSourcesPanel && playerShowSources { order.append(.sources) }
+        if canShowSubtitlePicker { order.append(.subtitles) }
         order.append(.settings)
         return order
+    }
+
+    private var canShowSubtitlePicker: Bool {
+        !subtitlePanelOptions(for: viewModel).isEmpty
+    }
+
+    private var subtitleNoneOption: SubtitlePanelOption? {
+        guard let off = viewModel.subtitles.first(where: { $0.id == "off" }) else { return nil }
+        return SubtitlePanelOption(
+            id: "off",
+            kind: .track(off),
+            badge: "",
+            title: "None",
+            detail: nil,
+            language: "",
+            isSelected: off.isSelected
+        )
+    }
+
+    private var subtitlePickerOptions: [SubtitlePanelOption] {
+        subtitlePanelOptions(for: viewModel)
+    }
+
+    private var builtInSubtitleOptions: [SubtitlePanelOption] {
+        subtitlePickerOptions.filter { option in
+            guard case .track(let track) = option.kind else { return false }
+            return track.externalFilename.isEmpty
+        }
+    }
+
+    private var externalSubtitleOptions: [SubtitlePanelOption] {
+        subtitlePickerOptions.filter { option in
+            switch option.kind {
+            case .track(let track):
+                return !track.externalFilename.isEmpty
+            case .external:
+                return true
+            }
+        }
     }
 
     /// Settings-style flash prevention: while the progress bar owns focus, only
@@ -311,6 +352,10 @@ struct PlayerControls: View {
                 .id("sources_button")
             }
 
+            if canShowSubtitlePicker {
+                subtitleMenuButton
+            }
+
             glassIconButton(
                 size: 70,
                 iconSize: 30,
@@ -368,6 +413,89 @@ struct PlayerControls: View {
         }
         .scaleEffect(isFocused ? 1.06 : 1.0)
         .animation(.easeOut(duration: 0.14), value: isFocused)
+    }
+
+    private var subtitleMenuButton: some View {
+        let isFocused = focusedControl == .subtitles
+
+        return Menu {
+            if let none = subtitleNoneOption {
+                Button {
+                    selectSubtitlePickerOption(none)
+                } label: {
+                    subtitleMenuItem(title: "None", isSelected: none.isSelected)
+                }
+            }
+
+            if !builtInSubtitleOptions.isEmpty {
+                Section("Built-In") {
+                    ForEach(builtInSubtitleOptions) { option in
+                        Button {
+                            selectSubtitlePickerOption(option)
+                        } label: {
+                            subtitleMenuItem(title: option.title, detail: option.detail, isSelected: option.isSelected)
+                        }
+                    }
+                }
+            }
+
+            if !externalSubtitleOptions.isEmpty {
+                Section("External Subtitles") {
+                    ForEach(externalSubtitleOptions) { option in
+                        Button {
+                            selectSubtitlePickerOption(option)
+                        } label: {
+                            subtitleMenuItem(title: option.title, detail: option.detail, isSelected: option.isSelected)
+                        }
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "captions.bubble")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundColor(isFocused ? .black : .white)
+                .frame(width: 70, height: 70)
+                .modifier(PlayerGlassCircleButtonBackground(filled: isFocused))
+                .shadow(color: .black.opacity(0.82), radius: 14, x: 0, y: 7)
+                .frame(width: 70, height: 70)
+                .clipShape(Circle())
+                .contentShape(Circle())
+        }
+        .menuStyle(.borderlessButton)
+        .focused($focusedControl, equals: .subtitles)
+        .focusEffectDisabledIfAvailable()
+        .onMoveCommand { direction in
+            handleMove(direction, from: .subtitles)
+        }
+        .scaleEffect(isFocused ? 1.06 : 1.0)
+        .animation(.easeOut(duration: 0.14), value: isFocused)
+        .id("subtitles_button")
+    }
+
+    private func subtitleMenuItem(title: String, detail: String? = nil, isSelected: Bool) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                if let detail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            Spacer()
+            if isSelected {
+                Image(systemName: "checkmark")
+            }
+        }
+    }
+
+    private func selectSubtitlePickerOption(_ option: SubtitlePanelOption) {
+        switch option.kind {
+        case .track(let track):
+            viewModel.selectSubtitle(track)
+        case .external(let subtitle):
+            viewModel.selectExternalSubtitle(subtitle)
+        }
     }
 
     // MARK: - Timeline
@@ -765,6 +893,51 @@ private enum SubtitleLanguageDisplay {
     }
 }
 
+/// Every pickable subtitle: mpv tracks first (embedded and orphaned
+/// externals), then the stream's add-on subtitles. Add-on entries that mpv
+/// has already loaded read their selection state off the matching track.
+@MainActor
+private func subtitlePanelOptions(for viewModel: PlayerViewModel) -> [SubtitlePanelOption] {
+    let externalUrls = Set(viewModel.availableExternalSubtitles.map(\.url))
+    var options: [SubtitlePanelOption] = []
+
+    for track in viewModel.subtitles where track.id != "off" {
+        // Loaded add-on subtitles are rendered from the add-on list below;
+        // listing their mpv track too would duplicate the row.
+        if !track.externalFilename.isEmpty, externalUrls.contains(track.externalFilename) { continue }
+        let isExternal = !track.externalFilename.isEmpty
+        let rawLanguage = track.language.isEmpty ? track.name : track.language
+        options.append(SubtitlePanelOption(
+            id: "track-\(track.id)",
+            kind: .track(track),
+            badge: isExternal ? "External" : "Built in",
+            title: track.name,
+            detail: nil,
+            language: SubtitleLanguageDisplay.name(for: rawLanguage),
+            isSelected: track.isSelected
+        ))
+    }
+
+    for subtitle in viewModel.availableExternalSubtitles {
+        let language = SubtitleLanguageDisplay.name(for: subtitle.language)
+        let loadedTrack = viewModel.subtitles.first { $0.externalFilename == subtitle.url }
+        let detail = subtitle.label.flatMap { label in
+            label.caseInsensitiveCompare(language) == .orderedSame ? nil : label
+        }
+        options.append(SubtitlePanelOption(
+            id: "ext-\(subtitle.url)",
+            kind: .external(subtitle),
+            badge: subtitle.source ?? "External",
+            title: language,
+            detail: detail,
+            language: language,
+            isSelected: loadedTrack?.isSelected ?? false
+        ))
+    }
+
+    return options
+}
+
 struct PlayerSettingsPanel: View {
     @ObservedObject var viewModel: PlayerViewModel
     var onClose: () -> Void
@@ -911,50 +1084,8 @@ struct PlayerSettingsPanel: View {
         .frame(maxHeight: .infinity, alignment: .top)
     }
 
-    /// Every pickable subtitle: mpv tracks first (embedded and orphaned
-    /// externals), then the stream's add-on subtitles. Add-on entries that mpv
-    /// has already loaded read their selection state off the matching track.
     private var allOptions: [SubtitlePanelOption] {
-        let externalUrls = Set(viewModel.availableExternalSubtitles.map(\.url))
-        var options: [SubtitlePanelOption] = []
-
-        for track in viewModel.subtitles where track.id != "off" {
-            // Loaded add-on subtitles are rendered from the add-on list below;
-            // listing their mpv track too would duplicate the row.
-            if !track.externalFilename.isEmpty, externalUrls.contains(track.externalFilename) { continue }
-            let isExternal = !track.externalFilename.isEmpty
-            // Untagged tracks often carry a language-like title ("English",
-            // "SDH"); grouping by it beats a catch-all "Unknown" bucket.
-            let rawLanguage = track.language.isEmpty ? track.name : track.language
-            options.append(SubtitlePanelOption(
-                id: "track-\(track.id)",
-                kind: .track(track),
-                badge: isExternal ? "External" : "Built in",
-                title: track.name,
-                detail: nil,
-                language: SubtitleLanguageDisplay.name(for: rawLanguage),
-                isSelected: track.isSelected
-            ))
-        }
-
-        for subtitle in viewModel.availableExternalSubtitles {
-            let language = SubtitleLanguageDisplay.name(for: subtitle.language)
-            let loadedTrack = viewModel.subtitles.first { $0.externalFilename == subtitle.url }
-            let detail = subtitle.label.flatMap { label in
-                label.caseInsensitiveCompare(language) == .orderedSame ? nil : label
-            }
-            options.append(SubtitlePanelOption(
-                id: "ext-\(subtitle.url)",
-                kind: .external(subtitle),
-                badge: subtitle.source ?? "External",
-                title: language,
-                detail: detail,
-                language: language,
-                isSelected: loadedTrack?.isSelected ?? false
-            ))
-        }
-
-        return options
+        subtitlePanelOptions(for: viewModel)
     }
 
     private var visibleOptions: [SubtitlePanelOption] {


### PR DESCRIPTION
## Summary
- Add a captions button beside the player transport controls.
- Use a native SwiftUI Menu for subtitle selection.
- Group options as None, Built-In, and External Subtitles.
- Reuse the existing subtitle-selection actions and shared option construction so the full settings panel remains consistent.

## Verification
- `xcodebuild ... build` — passed.
- `xcodebuild ... test -quiet` — passed with exit code 0.
- Installed and launched the app on the tvOS simulator.
- `git diff --check` — passed.
- Independent staged-diff review — passed with no security or logic findings.

## Imagery
<img width="1702" height="980" alt="CleanShot 2026-09-06 at 11 26 27@2x" src="https://github.com/user-attachments/assets/a7b93d07-6964-48ea-b0c0-bc623f149da8" />
<img width="1696" height="978" alt="CleanShot 2026-09-06 at 11 26 53@2x" src="https://github.com/user-attachments/assets/d2807ae4-6b0a-47dd-b33a-f8d6991e4f0b" />

Closes #35