### PR TITLE
fix(player): allow Apple TV sleep while playback is paused

### DIFF
--- a/tvosApp/NuvioTV.xcodeproj/project.pbxproj
+++ b/tvosApp/NuvioTV.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		AE10B009 /* NuvioTV/Sources/Core/Player/MPVPlaybackController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F009 /* NuvioTV/Sources/Core/Player/MPVPlaybackController.swift */; };
 		AE10B00A /* NuvioTV/Sources/UI/Player/PlayerSubtitleOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F00A /* NuvioTV/Sources/UI/Player/PlayerSubtitleOverlay.swift */; };
 		AE10B00B /* PlaybackBackendPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F00B /* PlaybackBackendPolicyTests.swift */; };
+		AE10B062 /* PlaybackIdlePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F062 /* PlaybackIdlePolicyTests.swift */; };
 		AE10B01A /* CatalogArtworkMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F01A /* CatalogArtworkMergeTests.swift */; };
 		AE10B00C /* NuvioTV/Sources/Core/Player/AISubtitleTranslationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F00C /* NuvioTV/Sources/Core/Player/AISubtitleTranslationCache.swift */; };
 		AE10B00E /* NuvioTV/Sources/Core/Player/AppleTVCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F00E /* NuvioTV/Sources/Core/Player/AppleTVCapability.swift */; };
@@ -233,6 +234,7 @@
 		AE10F009 /* NuvioTV/Sources/Core/Player/MPVPlaybackController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/MPVPlaybackController.swift; sourceTree = "<group>"; };
 		AE10F00A /* NuvioTV/Sources/UI/Player/PlayerSubtitleOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/UI/Player/PlayerSubtitleOverlay.swift; sourceTree = "<group>"; };
 		AE10F00B /* PlaybackBackendPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackBackendPolicyTests.swift; sourceTree = "<group>"; };
+		AE10F062 /* PlaybackIdlePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackIdlePolicyTests.swift; sourceTree = "<group>"; };
 		AE10F01A /* CatalogArtworkMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogArtworkMergeTests.swift; sourceTree = "<group>"; };
 		AE10F00C /* NuvioTV/Sources/Core/Player/AISubtitleTranslationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/AISubtitleTranslationCache.swift; sourceTree = "<group>"; };
 		AE10F00E /* NuvioTV/Sources/Core/Player/AppleTVCapability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/AppleTVCapability.swift; sourceTree = "<group>"; };
@@ -589,6 +591,7 @@
 			isa = PBXGroup;
 			children = (
 				AE10F00B /* PlaybackBackendPolicyTests.swift */,
+				AE10F062 /* PlaybackIdlePolicyTests.swift */,
 				AE10F01A /* CatalogArtworkMergeTests.swift */,
 				AE10F00F /* AppleTVCapabilityTests.swift */,
 				AE10F011 /* PictureInPictureTests.swift */,
@@ -794,6 +797,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AE10B00B /* PlaybackBackendPolicyTests.swift in Sources */,
+				AE10B062 /* PlaybackIdlePolicyTests.swift in Sources */,
 				AE10B01A /* CatalogArtworkMergeTests.swift in Sources */,
 				AE10B00F /* AppleTVCapabilityTests.swift in Sources */,
 				AE10B011 /* PictureInPictureTests.swift in Sources */,

--- a/tvosApp/NuvioTV/Sources/Core/Player/PlaybackWakeLock.swift
+++ b/tvosApp/NuvioTV/Sources/Core/Player/PlaybackWakeLock.swift
@@ -24,25 +24,50 @@ enum PlaybackAudioSession {
     }
 }
 
-/// Keeps Apple TV awake for the full player session.
+/// Whether the player session should block Apple TV screensaver / Sleep After.
 ///
-/// Custom MPV Metal rendering is not treated as "system video playback" the way
-/// a system video controller is, so tvOS can still honor Settings → General →
-/// Sleep After (often 15–30 minutes) unless the app explicitly disables the
-/// idle timer. Status-based toggling was too fragile: brief non-playing states
-/// re-enabled sleep while video continued.
+/// Custom MPV Metal rendering is not treated as system video playback, so tvOS
+/// honors Settings → General → Sleep After unless the idle timer is disabled.
+/// Hold the lock while video is loading or playing; drop it on pause, end, and
+/// error so screensaver and sleep can run. Source switches keep the lock even
+/// if status flickers, because those gaps are not user-idle.
+enum PlaybackIdlePolicy {
+    static func preventsIdle(
+        status: PlayerStatus,
+        isSwitchingSource: Bool = false,
+        isReloadingStream: Bool = false
+    ) -> Bool {
+        if isSwitchingSource || isReloadingStream {
+            return true
+        }
+        switch status {
+        case .playing, .buffering, .idle:
+            return true
+        case .paused, .ended, .error:
+            return false
+        }
+    }
+}
+
+/// Keeps Apple TV awake while playback is actually in progress.
 ///
-/// Hold this for the entire `PlayerView` lifetime (including pause/buffering),
-/// and reassert periodically in case the system or another UI path clears it.
+/// Acquire for the `PlayerView` lifetime (including Picture in Picture), then
+/// call `setPreventsIdle` as status changes so a paused session can sleep.
+/// Reassert periodically in case the system or another UI path clears the flag
+/// while video is still playing.
 @MainActor
 enum PlaybackWakeLock {
     private static var holdCount = 0
+    private static var preventsIdle = true
     private static var reassertTimer: Timer?
 
-    /// Begin preventing sleep. Nested acquires are reference-counted.
+    /// Begin a player-session hold. Nested acquires are reference-counted.
     static func acquire() {
         holdCount += 1
-        apply(disabled: true)
+        if holdCount == 1 {
+            preventsIdle = true
+        }
+        apply()
         activateAudioSession()
         startReassertTimerIfNeeded()
     }
@@ -53,17 +78,26 @@ enum PlaybackWakeLock {
         if holdCount == 0 {
             reassertTimer?.invalidate()
             reassertTimer = nil
-            apply(disabled: false)
+            preventsIdle = true
+            apply()
         }
     }
 
-    /// Force the idle timer off while a hold is active (safe to call often).
-    static func reassert() {
+    /// Update whether the current hold should block screensaver / sleep.
+    static func setPreventsIdle(_ value: Bool) {
+        preventsIdle = value
         guard holdCount > 0 else { return }
-        apply(disabled: true)
+        apply()
     }
 
-    private static func apply(disabled: Bool) {
+    /// Re-apply the current idle policy while a hold is active (safe to call often).
+    static func reassert() {
+        guard holdCount > 0 else { return }
+        apply()
+    }
+
+    private static func apply() {
+        let disabled = holdCount > 0 && preventsIdle
         if UIApplication.shared.isIdleTimerDisabled != disabled {
             UIApplication.shared.isIdleTimerDisabled = disabled
         }

--- a/tvosApp/NuvioTV/Sources/UI/Player/PlayerView.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Player/PlayerView.swift
@@ -417,9 +417,10 @@ struct PlayerView: View {
         .animation(.easeOut(duration: 0.22), value: viewModel.showPauseOverlay)
         .animation(.easeOut(duration: 0.22), value: viewModel.sidePanel)
         .onAppear {
-            // Hold for the full player session (not only .playing/.buffering).
-            // Status flicker previously re-enabled Sleep After mid-watch.
+            // Hold for the player session, then sync so pause/end can sleep
+            // without dropping the lock during buffering or source switches.
             PlaybackWakeLock.acquire()
+            syncPlaybackWakeLock()
             viewModel.load(
                 url: url,
                 meta: meta,
@@ -465,9 +466,7 @@ struct PlayerView: View {
             }
         }
         .onChange(of: viewModel.status) { _, status in
-            // Keep reasserting while the player is up — never re-enable sleep
-            // based on transient status (pause/buffer/error) mid-session.
-            PlaybackWakeLock.reassert()
+            syncPlaybackWakeLock()
             if status == .playing,
                !viewModel.isSwitchingSource,
                !viewModel.isReloadingStream,
@@ -487,10 +486,14 @@ struct PlayerView: View {
             onFinished()
         }
         .onChange(of: viewModel.isSwitchingSource) { _, isSwitching in
+            syncPlaybackWakeLock()
             if isSwitching {
                 PlaybackStartupTiming.start()
                 didReportPlaybackStarted = false
             }
+        }
+        .onChange(of: viewModel.isReloadingStream) { _, _ in
+            syncPlaybackWakeLock()
         }
         .onChange(of: viewModel.didDetectReplacementStream) { _, isReplacement in
             if isReplacement {
@@ -692,6 +695,16 @@ struct PlayerView: View {
             return "\(meta.id):\(numbers.season):\(numbers.episode)"
         }
         return meta.id
+    }
+
+    private func syncPlaybackWakeLock() {
+        PlaybackWakeLock.setPreventsIdle(
+            PlaybackIdlePolicy.preventsIdle(
+                status: viewModel.status,
+                isSwitchingSource: viewModel.isSwitchingSource,
+                isReloadingStream: viewModel.isReloadingStream
+            )
+        )
     }
 
     private func focusRemoteInput() {

--- a/tvosApp/NuvioTVTests/PlaybackIdlePolicyTests.swift
+++ b/tvosApp/NuvioTVTests/PlaybackIdlePolicyTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import NuvioTV
+
+final class PlaybackIdlePolicyTests: XCTestCase {
+
+    func testPlayingAndBufferingPreventSleep() {
+        XCTAssertTrue(PlaybackIdlePolicy.preventsIdle(status: .playing))
+        XCTAssertTrue(PlaybackIdlePolicy.preventsIdle(status: .buffering))
+        XCTAssertTrue(PlaybackIdlePolicy.preventsIdle(status: .idle))
+    }
+
+    func testPausedEndedAndErrorAllowSleep() {
+        XCTAssertFalse(PlaybackIdlePolicy.preventsIdle(status: .paused))
+        XCTAssertFalse(PlaybackIdlePolicy.preventsIdle(status: .ended))
+        XCTAssertFalse(PlaybackIdlePolicy.preventsIdle(status: .error("stream failed")))
+    }
+
+    func testSourceSwitchKeepsDeviceAwakeThroughPauseFlicker() {
+        XCTAssertTrue(
+            PlaybackIdlePolicy.preventsIdle(
+                status: .paused,
+                isSwitchingSource: true
+            )
+        )
+        XCTAssertTrue(
+            PlaybackIdlePolicy.preventsIdle(
+                status: .error("expired"),
+                isReloadingStream: true
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #62: paused playback no longer holds `isIdleTimerDisabled` for the whole player session, so Apple TV screensaver / Sleep After can run again.
- Adds `PlaybackIdlePolicy` and syncs `PlaybackWakeLock` from playback status — playing/buffering/idle and source reload keep the device awake; pause/end/error allow sleep.
- Includes unit coverage for the idle policy matrix.

## Test plan
- [x] Play a title on Apple TV, pause it, confirm screensaver / Sleep After can engage after the configured idle period
- [x] Resume playback and confirm the device stays awake while playing/buffering
- [x] Switch sources mid-playback and confirm brief status flicker does not allow sleep
- [x] End or error a stream and confirm sleep is allowed again
- [x] Run `PlaybackIdlePolicyTests`