### PR TITLE
fix(home): honor Catalog Add-on Names toggle on tvOS Home (#53)

### DIFF
--- a/tvosApp/NuvioTV/Sources/NuvioTVApp.swift
+++ b/tvosApp/NuvioTV/Sources/NuvioTVApp.swift
@@ -2875,6 +2875,7 @@ struct TVHomeView: View {
     @AppStorage(SettingsKey.homeLayout) private var homeLayout = "Modern"
     @AppStorage(SettingsKey.heroCatalogs) private var heroCatalogsData = Data()
     @AppStorage(SettingsKey.posterLabels) private var posterLabels = false
+    @AppStorage(SettingsKey.catalogAddonNames) private var catalogAddonNames = true
     @AppStorage(SettingsKey.tmdbEnabled) private var tmdbEnabled = false
     @AppStorage(SettingsKey.tmdbLanguage) private var tmdbLanguage = "en"
     @AppStorage(SettingsKey.tmdbUseArtwork) private var tmdbUseArtwork = true
@@ -3151,7 +3152,8 @@ struct TVHomeView: View {
                                         if section.isLoadingPlaceholder {
                                             TVLoadingCatalogRow(
                                                 title: section.title,
-                                                addonName: section.addonName
+                                                addonName: section.addonName,
+                                                showCatalogAddonNames: catalogAddonNames
                                             )
                                                 .frame(
                                                     height: estimatedHeight(for: section),
@@ -3213,6 +3215,7 @@ struct TVHomeView: View {
                                                 id: section.id,
                                                 title: section.title,
                                                 addonName: section.addonName,
+                                                showCatalogAddonNames: catalogAddonNames,
                                                 horizontalEdgeInset: horizontalEdgeInset,
                                                 items: section.items,
                                                 progressByItemId: (section.id == TVHomeSection.continueWatchingId || section.id == TVHomeSection.upcomingId)
@@ -3773,6 +3776,7 @@ struct TVHomeView: View {
                             id: section.id,
                             title: section.title,
                             addonName: section.addonName,
+                            showCatalogAddonNames: catalogAddonNames,
                             horizontalEdgeInset: heroBleed,
                             items: section.items,
                             progressByItemId: continueWatchingByMetaId,
@@ -3826,6 +3830,7 @@ struct TVHomeView: View {
                         TVHomeCatalogGridSection(
                             section: section,
                             watchedTitleKeys: watchedTitleKeys,
+                            showCatalogAddonNames: catalogAddonNames,
                             initialFocusCardKey: initialFocusCardKey,
                             externalFocus: $focusedCardID,
                             restrictFocusToCardKey: overlayRestoreCardID,

--- a/tvosApp/NuvioTV/Sources/UI/Home/TVCatalogRow.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Home/TVCatalogRow.swift
@@ -47,11 +47,12 @@ enum CollectionFolderGridMetrics {
 struct TVLoadingCatalogRow: View {
     let title: String
     var addonName: String? = nil
+    /// Passed from Home so toggling the setting redraws rows wrapped in `.equatable()`.
+    var showCatalogAddonNames: Bool = true
 
     @AppStorage(SettingsKey.homeLayout) private var homeLayout = "Modern"
     @AppStorage(SettingsKey.posterLabels) private var posterLabels = false
     @AppStorage(SettingsKey.liquidGlassCards) private var liquidGlassCards = true
-    @AppStorage(SettingsKey.catalogAddonNames) private var catalogAddonNames = true
     @AppStorage(SettingsKey.theme) private var theme = SettingsAccent.white.rawValue
 
     private var cardWidth: CGFloat { homeLayout == "Compact" ? 170 : 210 }
@@ -71,7 +72,7 @@ struct TVLoadingCatalogRow: View {
                     .font(.custom("Inter-Bold", size: 30))
                     .foregroundColor(.white)
 
-                if catalogAddonNames, let addonName = addonName, !addonName.isEmpty {
+                if showCatalogAddonNames, let addonName = addonName, !addonName.isEmpty {
                     Text(addonName)
                         .font(.custom("Inter-SemiBold", size: 16))
                         .foregroundColor(SettingsAccent.color(for: theme))
@@ -111,6 +112,8 @@ struct TVCatalogRow: View {
     let id: String
     let title: String
     var addonName: String? = nil
+    /// Passed from Home so toggling the setting redraws rows wrapped in `.equatable()`.
+    var showCatalogAddonNames: Bool = true
     let horizontalEdgeInset: CGFloat
     let items: [NuvioMeta]
     var progressByItemId: [String: ContinueWatchingItem] = [:]
@@ -138,7 +141,6 @@ struct TVCatalogRow: View {
     @State private var scrollIndex: Int?
     @AppStorage(SettingsKey.homeLayout) private var homeLayout = "Modern"
     @AppStorage(SettingsKey.posterLabels) private var posterLabels = false
-    @AppStorage(SettingsKey.catalogAddonNames) private var catalogAddonNames = true
     @AppStorage(SettingsKey.theme) private var theme = SettingsAccent.white.rawValue
     @AppStorage(SettingsKey.smoothFocus) private var smoothFocus = true
     @AppStorage(SettingsKey.focusHighlighter) private var focusHighlighter = false
@@ -207,7 +209,7 @@ struct TVCatalogRow: View {
                     .font(.custom("Inter-Bold", size: 30))
                     .foregroundColor(.white)
 
-                if catalogAddonNames, let addonName = addonName, !addonName.isEmpty {
+                if showCatalogAddonNames, let addonName = addonName, !addonName.isEmpty {
                     Text(addonName)
                         .font(.custom("Inter-SemiBold", size: 16))
                         .foregroundColor(SettingsAccent.color(for: theme))
@@ -404,6 +406,7 @@ extension TVCatalogRow: Equatable {
         return lhs.id == rhs.id
             && lhs.title == rhs.title
             && lhs.addonName == rhs.addonName
+            && lhs.showCatalogAddonNames == rhs.showCatalogAddonNames
             && lhs.horizontalEdgeInset == rhs.horizontalEdgeInset
             && lhs.items == rhs.items
             && lhs.watchedTitleKeys == rhs.watchedTitleKeys
@@ -450,6 +453,8 @@ enum TVHomeGridLayout {
 struct TVHomeCatalogGridSection: View {
     let section: TVHomeSection
     let watchedTitleKeys: Set<String>
+    /// Passed from Home so toggling the setting redraws while Home stays mounted.
+    var showCatalogAddonNames: Bool = true
     let initialFocusCardKey: String?
     var externalFocus: FocusState<String?>.Binding? = nil
     var restrictFocusToCardKey: String? = nil
@@ -461,7 +466,6 @@ struct TVHomeCatalogGridSection: View {
     let onSeeAllFocus: () -> Void
     let onSeeAll: () -> Void
 
-    @AppStorage(SettingsKey.catalogAddonNames) private var catalogAddonNames = true
     @AppStorage(SettingsKey.theme) private var theme = SettingsAccent.white.rawValue
 
     private var previewItems: [NuvioMeta] {
@@ -479,7 +483,7 @@ struct TVHomeCatalogGridSection: View {
                     .font(.custom("Inter-Bold", size: 30))
                     .foregroundColor(.white)
 
-                if catalogAddonNames, let addonName = section.addonName, !addonName.isEmpty {
+                if showCatalogAddonNames, let addonName = section.addonName, !addonName.isEmpty {
                     Text(addonName)
                         .font(.custom("Inter-SemiBold", size: 16))
                         .foregroundColor(SettingsAccent.color(for: theme))

--- a/tvosApp/NuvioTVTests/HomeLayoutSettingsTests.swift
+++ b/tvosApp/NuvioTVTests/HomeLayoutSettingsTests.swift
@@ -49,4 +49,65 @@ final class HomeLayoutSettingsTests: XCTestCase {
         defaults.set(false, forKey: SettingsKey.catalogAddonNames)
         XCTAssertFalse(defaults.bool(forKey: SettingsKey.catalogAddonNames))
     }
+
+    func testCatalogRowEqualityIncludesAddonNameVisibility() {
+        let meta = NuvioMeta(
+            id: "tt1",
+            name: "Title",
+            description: nil,
+            posterUrl: nil,
+            backgroundUrl: nil,
+            logoUrl: nil,
+            imdbId: nil,
+            tmdbId: nil,
+            type: "movie",
+            year: nil,
+            genres: nil,
+            rating: nil,
+            releaseInfo: nil,
+            runtime: nil,
+            cast: nil,
+            director: nil,
+            writer: nil,
+            certification: nil,
+            country: nil,
+            released: nil,
+            status: nil,
+            videos: nil,
+            trailerYtIds: nil,
+            externalRatings: nil
+        )
+        let shown = TVCatalogRow(
+            id: "row",
+            title: "Popular",
+            addonName: "Cinemeta",
+            showCatalogAddonNames: true,
+            horizontalEdgeInset: 0,
+            items: [meta],
+            initialFocusCardKey: nil,
+            landscapeFocusedId: nil,
+            onInitialFocusRequested: {},
+            onFocus: { _ in },
+            onBlur: { _ in },
+            onApproachEnd: { _ in },
+            onSelect: { _ in }
+        )
+        let hidden = TVCatalogRow(
+            id: "row",
+            title: "Popular",
+            addonName: "Cinemeta",
+            showCatalogAddonNames: false,
+            horizontalEdgeInset: 0,
+            items: [meta],
+            initialFocusCardKey: nil,
+            landscapeFocusedId: nil,
+            onInitialFocusRequested: {},
+            onFocus: { _ in },
+            onBlur: { _ in },
+            onApproachEnd: { _ in },
+            onSelect: { _ in }
+        )
+        XCTAssertNotEqual(shown, hidden)
+        XCTAssertEqual(shown, shown)
+    }
 }


### PR DESCRIPTION
## Summary
- Home catalog rows were wrapped in `.equatable()` while the Catalog Add-on Names badge was read from `@AppStorage` inside the row, so toggling the setting did not force a redraw while Home stayed mounted.
- Pass `showCatalogAddonNames` from `TVHomeView` into `TVCatalogRow`, `TVLoadingCatalogRow`, and `TVHomeCatalogGridSection`, and include it in `TVCatalogRow`’s `Equatable` comparison.
- Add a unit test that equality changes when the visibility flag flips.

Fixes #53

## Test plan
- [ ] On Apple TV Home, disable **Catalog Add-on Names** in Settings and confirm addon name badges disappear without leaving Home
- [ ] Re-enable the setting and confirm badges reappear
- [ ] Confirm Compact / Modern / Grid View all respect the toggle
- [ ] Run `HomeLayoutSettingsTests`