### PR TITLE
feat(settings): Clear Cache without resetting preferences (#54)

### DIFF
--- a/tvosApp/NuvioTV.xcodeproj/project.pbxproj
+++ b/tvosApp/NuvioTV.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		AE10B01D /* PlayerControlsSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F01D /* PlayerControlsSettingsTests.swift */; };
 		AE10B01E /* AuthReauthFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F01E /* AuthReauthFlowTests.swift */; };
 		AE10B01F /* HomeLayoutSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F01F /* HomeLayoutSettingsTests.swift */; };
+		AE10B020 /* TVCacheClearingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F020 /* TVCacheClearingTests.swift */; };
 		AE10B010 /* NuvioTV/Sources/Core/Player/PictureInPictureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE10F010 /* NuvioTV/Sources/Core/Player/PictureInPictureManager.swift */; };
 		C0D310010000000000000001 /* NuvioTV/Sources/NuvioTVApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300010000000000000001 /* NuvioTV/Sources/NuvioTVApp.swift */; };
 		C0D310020000000000000002 /* NuvioTV/Sources/Models/CatalogModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300020000000000000002 /* NuvioTV/Sources/Models/CatalogModels.swift */; };
@@ -133,6 +134,7 @@
 		C0D310FA00000000000000FA /* NuvioTV/Sources/Models/WatchProgressLedger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300FA00000000000000FA /* NuvioTV/Sources/Models/WatchProgressLedger.swift */; };
 		C0D310FB00000000000000FB /* NuvioTV/Sources/Core/Sync/ContinueWatchingBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300FB00000000000000FB /* NuvioTV/Sources/Core/Sync/ContinueWatchingBuilder.swift */; };
 		C0D310FC00000000000000FC /* NuvioTV/Sources/Core/Sync/ContinueWatchingTestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300FC00000000000000FC /* NuvioTV/Sources/Core/Sync/ContinueWatchingTestData.swift */; };
+		C0D310FE00000000000000FE /* NuvioTV/Sources/Core/Sync/TVCacheClearing.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300FE00000000000000FE /* NuvioTV/Sources/Core/Sync/TVCacheClearing.swift */; };
 		F0A100020000000000000001 /* inter_variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F0A100010000000000000001 /* inter_variable.ttf */; };
 		T0D310E200000000000000E2 /* StreamsDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T0D300E200000000000000E2 /* StreamsDiscoveryTests.swift */; };
 		T0D310E3 /* StreamQualityTagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T0D300E3 /* StreamQualityTagsTests.swift */; };
@@ -243,6 +245,7 @@
 		AE10F01D /* PlayerControlsSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlsSettingsTests.swift; sourceTree = "<group>"; };
 		AE10F01E /* AuthReauthFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthReauthFlowTests.swift; sourceTree = "<group>"; };
 		AE10F01F /* HomeLayoutSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLayoutSettingsTests.swift; sourceTree = "<group>"; };
+		AE10F020 /* TVCacheClearingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVCacheClearingTests.swift; sourceTree = "<group>"; };
 		AE10F010 /* NuvioTV/Sources/Core/Player/PictureInPictureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/PictureInPictureManager.swift; sourceTree = "<group>"; };
 		B7646E52916949A3A8EF6748 /* Pods-NuvioTV.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NuvioTV.debug.xcconfig"; path = "Target Support Files/Pods-NuvioTV/Pods-NuvioTV.debug.xcconfig"; sourceTree = "<group>"; };
 		C0D300010000000000000001 /* NuvioTV/Sources/NuvioTVApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/NuvioTVApp.swift; sourceTree = "<group>"; };
@@ -315,6 +318,7 @@
 		C0D300FA00000000000000FA /* NuvioTV/Sources/Models/WatchProgressLedger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Models/WatchProgressLedger.swift; sourceTree = "<group>"; };
 		C0D300FB00000000000000FB /* NuvioTV/Sources/Core/Sync/ContinueWatchingBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Sync/ContinueWatchingBuilder.swift; sourceTree = "<group>"; };
 		C0D300FC00000000000000FC /* NuvioTV/Sources/Core/Sync/ContinueWatchingTestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Sync/ContinueWatchingTestData.swift; sourceTree = "<group>"; };
+		C0D300FE00000000000000FE /* NuvioTV/Sources/Core/Sync/TVCacheClearing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Sync/TVCacheClearing.swift; sourceTree = "<group>"; };
 		F0A100010000000000000001 /* inter_variable.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = inter_variable.ttf; path = NuvioTV/Fonts/inter_variable.ttf; sourceTree = "<group>"; };
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = NuvioTV/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* NuvioTV-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "NuvioTV-Bridging-Header.h"; path = "NuvioTV/NuvioTV-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -490,6 +494,7 @@
 				C0D30060 /* NuvioTV/Sources/Core/Streams/StreamQualityTags.swift */,
 				C0D300FB00000000000000FB /* NuvioTV/Sources/Core/Sync/ContinueWatchingBuilder.swift */,
 				C0D300FC00000000000000FC /* NuvioTV/Sources/Core/Sync/ContinueWatchingTestData.swift */,
+				C0D300FE00000000000000FE /* NuvioTV/Sources/Core/Sync/TVCacheClearing.swift */,
 				C0D3002B000000000000002B /* NuvioTV/Sources/Core/Sync/NuvioSyncService.swift */,
 				C0D300FD00000000000000FD /* NuvioTV/Sources/Core/Sync/ICloudSettingsSyncManager.swift */,
 				C0D30070 /* NuvioTV/Sources/Core/TMDB/TmdbDetailsService.swift */,
@@ -597,6 +602,7 @@
 				AE10F01D /* PlayerControlsSettingsTests.swift */,
 				AE10F01E /* AuthReauthFlowTests.swift */,
 				AE10F01F /* HomeLayoutSettingsTests.swift */,
+				AE10F020 /* TVCacheClearingTests.swift */,
 				T0D300E200000000000000E2 /* StreamsDiscoveryTests.swift */,
 				T0D300E3 /* StreamQualityTagsTests.swift */,
 				T0D300E4 /* CatalogDecodingTests.swift */,
@@ -802,6 +808,7 @@
 				AE10B01D /* PlayerControlsSettingsTests.swift in Sources */,
 				AE10B01E /* AuthReauthFlowTests.swift in Sources */,
 				AE10B01F /* HomeLayoutSettingsTests.swift in Sources */,
+				AE10B020 /* TVCacheClearingTests.swift in Sources */,
 				T0D310E200000000000000E2 /* StreamsDiscoveryTests.swift in Sources */,
 				T0D310E3 /* StreamQualityTagsTests.swift in Sources */,
 				T0D310E4 /* CatalogDecodingTests.swift in Sources */,
@@ -890,6 +897,7 @@
 				C0D310FA00000000000000FA /* NuvioTV/Sources/Models/WatchProgressLedger.swift in Sources */,
 				C0D310FB00000000000000FB /* NuvioTV/Sources/Core/Sync/ContinueWatchingBuilder.swift in Sources */,
 				C0D310FC00000000000000FC /* NuvioTV/Sources/Core/Sync/ContinueWatchingTestData.swift in Sources */,
+				C0D310FE00000000000000FE /* NuvioTV/Sources/Core/Sync/TVCacheClearing.swift in Sources */,
 				C0D310FD00000000000000FD /* NuvioTV/Sources/Core/Sync/ICloudSettingsSyncManager.swift in Sources */,
 				C0D3102C000000000000002C /* NuvioTV/Sources/Core/Trakt/TraktAuthService.swift in Sources */,
 				51A100020000000000000002 /* NuvioTV/Sources/Core/Simkl/SimklAPIClient.swift in Sources */,

--- a/tvosApp/NuvioTV/Sources/Core/Sync/TVCacheClearing.swift
+++ b/tvosApp/NuvioTV/Sources/Core/Sync/TVCacheClearing.swift
@@ -1,0 +1,65 @@
+//
+//  TVCacheClearing.swift
+//  NuvioTV
+//
+//  Clears transient Home/artwork caches while preserving user settings.
+//
+
+import Foundation
+
+/// Wipes poster/image caches, local Home catalog order, and row scroll
+/// positions, then asks account sync to pull a fresh layout from the server.
+enum TVCacheClearing {
+    static let clearedNotification = Notification.Name("nuvio.tv.cache.cleared")
+
+    /// Keys that describe cached Home layout/row state — not preference toggles.
+    private static let layoutCacheKeys = [
+        SettingsKey.homeCatalogOrder,
+        SettingsKey.homeCatalogTitles,
+        SettingsKey.homeCatalogSyncedOrder
+    ]
+
+    @MainActor
+    static func clearAndRefresh() async {
+        await purgeImageCaches()
+        clearCatalogMetadataCache()
+        clearHomeLayoutCaches()
+        await StreamsRepository.clearManifestCache()
+
+        NotificationCenter.default.post(name: clearedNotification, object: nil)
+
+        // Prefer a forced account pull so catalog order returns from the web;
+        // fall back to bumping the Home revision when signed out.
+        if let sync = NuvioSyncManager.current, AuthConfig.isConfigured {
+            sync.retryInitialAccountPull()
+        } else {
+            NotificationCenter.default.post(
+                name: NuvioSyncManager.homeContentSyncedNotification,
+                object: nil
+            )
+        }
+    }
+
+    private static func clearHomeLayoutCaches() {
+        let defaults = ProfileSettings.current
+        for key in layoutCacheKeys {
+            defaults.removeObject(forKey: key)
+        }
+        NotificationCenter.default.post(name: TVHomeCatalogOrder.changedNotification, object: nil)
+        NotificationCenter.default.post(
+            name: TVHomeCatalogOrder.snapshotChangedNotification,
+            object: nil
+        )
+    }
+
+    private static func clearCatalogMetadataCache() {
+        CinemetaCatalogRepository.clearMetadataCache()
+    }
+
+    private static func purgeImageCaches() async {
+        await PosterArtworkCache.shared.purgeAll()
+        await BackdropImageCache.shared.purge()
+        await PersonProfileImageCache.shared.purge()
+        URLCache.shared.removeAllCachedResponses()
+    }
+}

--- a/tvosApp/NuvioTV/Sources/Data/Repository/CatalogRepository.swift
+++ b/tvosApp/NuvioTV/Sources/Data/Repository/CatalogRepository.swift
@@ -320,6 +320,14 @@ final class CinemetaCatalogRepository: CatalogRepository {
         }
     }
 
+    /// Drops in-memory metadata so the next Home/details load re-fetches from the network.
+    static func clearMetadataCache() {
+        metadataCacheQueue.sync(flags: .barrier) {
+            cachedMetaById.removeAll(keepingCapacity: false)
+            cachedFullMetaIds.removeAll(keepingCapacity: false)
+        }
+    }
+
     func getHomeCatalogs() async throws -> [NuvioCatalog] {
         try await loadHomeCatalogs()
     }

--- a/tvosApp/NuvioTV/Sources/Data/Repository/StreamsRepository.swift
+++ b/tvosApp/NuvioTV/Sources/Data/Repository/StreamsRepository.swift
@@ -28,6 +28,10 @@ final class StreamsRepository: ObservableObject {
     /// Actor-backed success-only cache (no permanent failure entries).
     private static let manifestCache = StreamManifestCache()
 
+    static func clearManifestCache() async {
+        await manifestCache.removeAll()
+    }
+
     private init() {}
 
     // MARK: - Request key

--- a/tvosApp/NuvioTV/Sources/NuvioTVApp.swift
+++ b/tvosApp/NuvioTV/Sources/NuvioTVApp.swift
@@ -3558,6 +3558,15 @@ struct TVHomeView: View {
                 await reloadHomeAfterSyncedInputs(for: identity)
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: TVCacheClearing.clearedNotification)) { _ in
+            rowScrollStore.removeAll()
+            store.reset()
+            homeReloadTask?.cancel()
+            let identity = contentIdentity
+            homeReloadTask = Task { @MainActor in
+                await reloadHomeAfterSyncedInputs(for: identity)
+            }
+        }
         .onDisappear {
             focusWork.cancelAll()
             homeReloadTask?.cancel()

--- a/tvosApp/NuvioTV/Sources/UI/Components/PosterCard.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Components/PosterCard.swift
@@ -1683,6 +1683,14 @@ actor PosterArtworkCache {
         cache.removeAllObjects()
     }
 
+    /// Memory + on-disk poster artwork. Used by Settings → Clear Cache.
+    func purgeAll() async {
+        cache.removeAllObjects()
+        inFlight.values.forEach { $0.cancel() }
+        inFlight.removeAll()
+        await PosterDiskCache.shared.purge()
+    }
+
     func image(for url: URL, maxPixelSize: Int) async -> UIImage? {
         let boundedPixelSize = min(max(maxPixelSize, 160), 1400)
         let key = "\(url.absoluteString)#\(boundedPixelSize)" as NSString
@@ -1815,6 +1823,18 @@ private actor PosterDiskCache {
         guard bytesWrittenSinceTrim >= trimInterval else { return }
         bytesWrittenSinceTrim = 0
         trim()
+    }
+
+    func purge() {
+        guard let files = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ) else { return }
+        for file in files {
+            try? fileManager.removeItem(at: file)
+        }
+        bytesWrittenSinceTrim = 0
+        posterURLSession.configuration.urlCache?.removeAllCachedResponses()
     }
 
     private func fileURL(for url: URL) -> URL {

--- a/tvosApp/NuvioTV/Sources/UI/Settings/SettingsView.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Settings/SettingsView.swift
@@ -6830,6 +6830,8 @@ private struct AdvancedSettingsView: View {
     @AppStorage(SettingsKey.playbackDebug) private var playbackDebug = false
     @State private var isSeedingTestHistory = false
     @State private var testHistoryStatus = ContinueWatchingTestData.status
+    @State private var isClearingCache = false
+    @State private var cacheStatus = ""
     @AppStorage(SettingsKey.focusHighlighter) private var focusHighlighter = false
     @AppStorage(SettingsKey.iCloudSyncEnabled) private var iCloudSyncEnabled = false
     @ObservedObject private var iCloudSyncManager = ICloudSettingsSyncManager.shared
@@ -7003,6 +7005,38 @@ private struct AdvancedSettingsView: View {
                     value: L10n.string("subtitle_style_reset", fallback: "Reset"),
                     accentColor: accentColor,
                     action: resetSettings
+                )
+            }
+
+            SettingsGroup(
+                title: L10n.string("tvos_settings_cache_title", fallback: "Cache"),
+                subtitle: L10n.string(
+                    "tvos_settings_cache_subtitle",
+                    fallback: "Free stuck artwork and Home row data without changing your settings"
+                )
+            ) {
+                SettingsActionRow(
+                    title: L10n.string("tvos_settings_clear_cache", fallback: "Clear Cache"),
+                    subtitle: L10n.string(
+                        "tvos_settings_clear_cache_subtitle",
+                        fallback: "Keeps settings; clears posters, catalog order, and row positions, then pulls fresh Home data"
+                    ),
+                    value: isClearingCache
+                        ? L10n.string("tvos_settings_clear_cache_working", fallback: "Working…")
+                        : (cacheStatus.isEmpty
+                            ? L10n.string("tvos_settings_clear_cache_action", fallback: "Clear")
+                            : cacheStatus),
+                    accentColor: accentColor,
+                    action: {
+                        guard !isClearingCache else { return }
+                        isClearingCache = true
+                        cacheStatus = ""
+                        Task { @MainActor in
+                            await TVCacheClearing.clearAndRefresh()
+                            cacheStatus = L10n.string("tvos_settings_clear_cache_done", fallback: "Done")
+                            isClearingCache = false
+                        }
+                    }
                 )
             }
         }

--- a/tvosApp/NuvioTVTests/TVCacheClearingTests.swift
+++ b/tvosApp/NuvioTVTests/TVCacheClearingTests.swift
@@ -6,16 +6,17 @@ final class TVCacheClearingTests: XCTestCase {
         XCTAssertEqual(TVCacheClearing.clearedNotification.rawValue, "nuvio.tv.cache.cleared")
     }
 
-    func testLayoutCacheKeysAreDistinctFromCoreSettings() {
-        // Clear Cache must wipe layout/order blobs, not preference toggles.
+    func testLayoutCacheKeysAreDistinctFromPreferenceToggles() {
+        // Clear Cache wipes layout/order blobs while preference toggles stay put.
         let layoutKeys: Set<String> = [
             SettingsKey.homeCatalogOrder,
             SettingsKey.homeCatalogTitles,
             SettingsKey.homeCatalogSyncedOrder
         ]
-        XCTAssertTrue(layoutKeys.isSubset(of: Set(SettingsKey.all)))
         XCTAssertFalse(layoutKeys.contains(SettingsKey.catalogAddonNames))
         XCTAssertFalse(layoutKeys.contains(SettingsKey.homeLayout))
         XCTAssertFalse(layoutKeys.contains(SettingsKey.theme))
+        XCTAssertTrue(SettingsKey.all.contains(SettingsKey.catalogAddonNames))
+        XCTAssertTrue(SettingsKey.all.contains(SettingsKey.homeLayout))
     }
 }

--- a/tvosApp/NuvioTVTests/TVCacheClearingTests.swift
+++ b/tvosApp/NuvioTVTests/TVCacheClearingTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import NuvioTV
+
+final class TVCacheClearingTests: XCTestCase {
+    func testClearedNotificationName() {
+        XCTAssertEqual(TVCacheClearing.clearedNotification.rawValue, "nuvio.tv.cache.cleared")
+    }
+
+    func testLayoutCacheKeysAreDistinctFromCoreSettings() {
+        // Clear Cache must wipe layout/order blobs, not preference toggles.
+        let layoutKeys: Set<String> = [
+            SettingsKey.homeCatalogOrder,
+            SettingsKey.homeCatalogTitles,
+            SettingsKey.homeCatalogSyncedOrder
+        ]
+        XCTAssertTrue(layoutKeys.isSubset(of: Set(SettingsKey.all)))
+        XCTAssertFalse(layoutKeys.contains(SettingsKey.catalogAddonNames))
+        XCTAssertFalse(layoutKeys.contains(SettingsKey.homeLayout))
+        XCTAssertFalse(layoutKeys.contains(SettingsKey.theme))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **Settings → Advanced → Clear Cache** that keeps user settings while wiping poster/image caches, local Home catalog order/snapshot data, and row scroll positions.
- Posts a Home reload signal and triggers an account pull so catalog order and row content come back fresh from the network/sync.
- Includes focused unit coverage for the notification name and layout-key vs preference-key boundary.

Fixes #54

## Test plan
- [x] Open Settings → Advanced → Clear Cache
- [x] Confirm preference toggles (theme, layout mode, Catalog Add-on Names, etc.) are unchanged
- [x] Confirm Home posters refetch and row scroll positions reset
- [x] Confirm Home catalog order refreshes from account sync / network
- [ ] Run `TVCacheClearingTests`