### PR TITLE
fix(player): make addon subtitles download and render (#57)

### DIFF
--- a/tvosApp/NuvioTV.xcodeproj/project.pbxproj
+++ b/tvosApp/NuvioTV.xcodeproj/project.pbxproj
@@ -142,6 +142,8 @@
 		PP0110030000000000000003 /* NuvioTV/Sources/UI/Player/PostPlayRecommendationOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = PP0100030000000000000003 /* NuvioTV/Sources/UI/Player/PostPlayRecommendationOverlay.swift */; };
 		PP0110040000000000000004 /* PostPlayRecommendationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PP0100040000000000000004 /* PostPlayRecommendationTests.swift */; };
 		PP0110050000000000000005 /* NuvioTV/Sources/UI/Player/PlayerLoadingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = PP0100050000000000000005 /* NuvioTV/Sources/UI/Player/PlayerLoadingOverlay.swift */; };
+		AE57B001 /* NuvioTV/Sources/Core/Player/ExternalSubtitleFileCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE57F001 /* NuvioTV/Sources/Core/Player/ExternalSubtitleFileCache.swift */; };
+		AE57B002 /* ExternalSubtitleFileCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE57F002 /* ExternalSubtitleFileCacheTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -235,6 +237,8 @@
 		AE10F00B /* PlaybackBackendPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackBackendPolicyTests.swift; sourceTree = "<group>"; };
 		AE10F01A /* CatalogArtworkMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogArtworkMergeTests.swift; sourceTree = "<group>"; };
 		AE10F00C /* NuvioTV/Sources/Core/Player/AISubtitleTranslationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/AISubtitleTranslationCache.swift; sourceTree = "<group>"; };
+		AE57F001 /* NuvioTV/Sources/Core/Player/ExternalSubtitleFileCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/ExternalSubtitleFileCache.swift; sourceTree = "<group>"; };
+		AE57F002 /* ExternalSubtitleFileCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalSubtitleFileCacheTests.swift; sourceTree = "<group>"; };
 		AE10F00E /* NuvioTV/Sources/Core/Player/AppleTVCapability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuvioTV/Sources/Core/Player/AppleTVCapability.swift; sourceTree = "<group>"; };
 		AE10F00F /* AppleTVCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleTVCapabilityTests.swift; sourceTree = "<group>"; };
 		AE10F011 /* PictureInPictureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PictureInPictureTests.swift; sourceTree = "<group>"; };
@@ -467,6 +471,7 @@
 				C0D3002F000000000000002F /* NuvioTV/Sources/Core/Debrid/RealDebridResolver.swift */,
 				C0D300320000000000000032 /* NuvioTV/Sources/Core/Debrid/TorboxResolver.swift */,
 				AE10F00C /* NuvioTV/Sources/Core/Player/AISubtitleTranslationCache.swift */,
+				AE57F001 /* NuvioTV/Sources/Core/Player/ExternalSubtitleFileCache.swift */,
 				AE10F007 /* NuvioTV/Sources/Core/Player/AetherPlaybackController.swift */,
 				AE10F00E /* NuvioTV/Sources/Core/Player/AppleTVCapability.swift */,
 				AE10F009 /* NuvioTV/Sources/Core/Player/MPVPlaybackController.swift */,
@@ -597,6 +602,7 @@
 				AE10F01D /* PlayerControlsSettingsTests.swift */,
 				AE10F01E /* AuthReauthFlowTests.swift */,
 				AE10F01F /* HomeLayoutSettingsTests.swift */,
+				AE57F002 /* ExternalSubtitleFileCacheTests.swift */,
 				T0D300E200000000000000E2 /* StreamsDiscoveryTests.swift */,
 				T0D300E3 /* StreamQualityTagsTests.swift */,
 				T0D300E4 /* CatalogDecodingTests.swift */,
@@ -802,6 +808,7 @@
 				AE10B01D /* PlayerControlsSettingsTests.swift in Sources */,
 				AE10B01E /* AuthReauthFlowTests.swift in Sources */,
 				AE10B01F /* HomeLayoutSettingsTests.swift in Sources */,
+				AE57B002 /* ExternalSubtitleFileCacheTests.swift in Sources */,
 				T0D310E200000000000000E2 /* StreamsDiscoveryTests.swift in Sources */,
 				T0D310E3 /* StreamQualityTagsTests.swift in Sources */,
 				T0D310E4 /* CatalogDecodingTests.swift in Sources */,
@@ -873,6 +880,7 @@
 				AE10B008 /* NuvioTV/Sources/Core/Player/PlaybackSessionCoordinator.swift in Sources */,
 				AE10B009 /* NuvioTV/Sources/Core/Player/MPVPlaybackController.swift in Sources */,
 				AE10B00C /* NuvioTV/Sources/Core/Player/AISubtitleTranslationCache.swift in Sources */,
+				AE57B001 /* NuvioTV/Sources/Core/Player/ExternalSubtitleFileCache.swift in Sources */,
 				AE10B00A /* NuvioTV/Sources/UI/Player/PlayerSubtitleOverlay.swift in Sources */,
 				C0D31051 /* NuvioTV/Sources/Core/Player/PlaybackEngineControlling.swift in Sources */,
 				AE10B010 /* NuvioTV/Sources/Core/Player/PictureInPictureManager.swift in Sources */,

--- a/tvosApp/NuvioTV/Sources/Core/Player/AetherPlaybackController.swift
+++ b/tvosApp/NuvioTV/Sources/Core/Player/AetherPlaybackController.swift
@@ -1492,7 +1492,7 @@ enum AetherExternalSubtitleIdentity {
         _ subtitles: [NuvioSubtitle]
     ) -> [(subtitle: NuvioSubtitle, url: URL)] {
         subtitles.compactMap { subtitle in
-            guard !subtitle.url.isEmpty, let url = URL(string: subtitle.url) else { return nil }
+            guard !subtitle.engineURL.isEmpty, let url = URL(string: subtitle.engineURL) else { return nil }
             return (subtitle, url)
         }
     }
@@ -1505,19 +1505,23 @@ struct AetherExternalSubtitleRegistration {
 
     static func make(
         subtitles: [NuvioSubtitle],
-        httpHeaders: [String: String]
+        httpHeaders _: [String: String]
     ) -> AetherExternalSubtitleRegistration {
         var tracks: [ExternalSubtitleTrack] = []
         var urlsByTrackID: [Int: String] = [:]
         for (subtitle, url) in AetherExternalSubtitleIdentity.accepted(subtitles) {
             let language = subtitle.language
             let id = AetherEngine.externalSubtitleTrackIDBase + tracks.count
+            // Add-on subtitle hosts must not inherit stream/debrid auth headers.
+            // An empty dictionary (not nil) prevents Aether from falling back to
+            // LoadOptions.httpHeaders during sidecar decode.
             tracks.append(
                 ExternalSubtitleTrack(
                     url: url,
                     name: subtitle.label ?? (language.isEmpty ? nil : language),
                     language: language.isEmpty ? nil : language,
-                    httpHeaders: httpHeaders.isEmpty ? nil : httpHeaders
+                    httpHeaders: [:],
+                    formatHint: subtitle.formatHint
                 )
             )
             urlsByTrackID[id] = subtitle.url
@@ -2400,13 +2404,16 @@ final class AetherPlaybackController: UIViewController, PlaybackEngineControllin
     }
 
     func addSubtitle(_ subtitle: NuvioSubtitle, select: Bool) {
-        guard let url = URL(string: subtitle.url) else { return }
+        guard let url = URL(string: subtitle.engineURL) else { return }
         let lang = subtitle.language
         let track = ExternalSubtitleTrack(
             url: url,
             name: subtitle.label ?? (lang.isEmpty ? nil : lang),
             language: lang.isEmpty ? nil : lang,
-            httpHeaders: currentHTTPHeaders.isEmpty ? nil : currentHTTPHeaders
+            // Empty dictionary — never nil — so sidecar decode does not inherit
+            // stream LoadOptions.httpHeaders (OpenSubtitles / subDL hosts).
+            httpHeaders: [:],
+            formatHint: subtitle.formatHint
         )
         let info = engine.addExternalSubtitleTrack(track)
         externalSubtitleURLsByTrackID[info.id] = subtitle.url

--- a/tvosApp/NuvioTV/Sources/Core/Player/ExternalSubtitleFileCache.swift
+++ b/tvosApp/NuvioTV/Sources/Core/Player/ExternalSubtitleFileCache.swift
@@ -1,0 +1,222 @@
+//
+//  ExternalSubtitleFileCache.swift
+//  NuvioTV
+//
+//  Downloads add-on subtitle sidecars to local files so MPV/Aether can load them
+//  without stream proxy headers or extensionless remote paths.
+//
+
+import CryptoKit
+import Foundation
+
+/// Resolves remote add-on subtitle URLs into local files the playback engines
+/// can open reliably. OpenSubtitles / subDL links often omit a file extension
+/// and must not inherit debrid/stream `http-header-fields`.
+actor ExternalSubtitleFileCache {
+    static let shared = ExternalSubtitleFileCache()
+
+    private let fileManager = FileManager.default
+    private let directory: URL
+    private var inFlight: [String: Task<URL?, Never>] = [:]
+
+    init() {
+        let caches = fileManager.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        directory = caches.appendingPathComponent("external_subtitles", isDirectory: true)
+        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    /// Returns a `file://` URL ready for `sub-add` / Aether sidecar decode.
+    func resolvedFileURL(for subtitle: NuvioSubtitle) async -> URL? {
+        guard let remote = URL(string: subtitle.url), !subtitle.url.isEmpty else { return nil }
+        if remote.isFileURL { return remote }
+
+        let key = subtitle.url
+        if let existing = cachedFile(for: key) { return existing }
+
+        if let task = inFlight[key] {
+            return await task.value
+        }
+
+        let task = Task<URL?, Never> {
+            await self.downloadAndStore(remote: remote, cacheKey: key)
+        }
+        inFlight[key] = task
+        let result = await task.value
+        inFlight[key] = nil
+        return result
+    }
+
+    /// Copies the subtitle with a local `playbackURL` (and format hint) when possible.
+    func prepare(_ subtitle: NuvioSubtitle) async -> NuvioSubtitle {
+        guard let local = await resolvedFileURL(for: subtitle) else { return subtitle }
+        var prepared = subtitle
+        prepared.playbackURL = local.absoluteString
+        if prepared.formatHint == nil {
+            prepared.formatHint = ExternalSubtitleFormat.hint(forFileURL: local)
+        }
+        return prepared
+    }
+
+    func purge() {
+        inFlight.values.forEach { $0.cancel() }
+        inFlight.removeAll()
+        guard let files = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ) else { return }
+        for file in files {
+            try? fileManager.removeItem(at: file)
+        }
+    }
+
+    private func cachedFile(for key: String) -> URL? {
+        let candidates = ["srt", "vtt", "ass", "ssa"].map { fileURL(for: key, ext: $0) }
+        return candidates.first { fileManager.fileExists(atPath: $0.path) }
+    }
+
+    private func downloadAndStore(remote: URL, cacheKey: String) async -> URL? {
+        var request = URLRequest(url: remote)
+        request.timeoutInterval = 20
+        request.setValue(
+            "Mozilla/5.0 (AppleTV; tvOS 18.0) AppleWebKit/605.1.15",
+            forHTTPHeaderField: "User-Agent"
+        )
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let http = response as? HTTPURLResponse,
+              200..<300 ~= http.statusCode,
+              !data.isEmpty else {
+            return nil
+        }
+
+        // ZIP archives from some providers are uncommon on the Stremio UTF-8
+        // proxy path; reject them rather than feeding binary zip bytes to mpv.
+        if ExternalSubtitleFormat.isZip(data) {
+            return nil
+        }
+
+        guard let extracted = ExternalSubtitleFormat.payload(
+            data: data,
+            response: http,
+            sourceURL: remote
+        ) else {
+            return nil
+        }
+
+        let destination = fileURL(for: cacheKey, ext: extracted.fileExtension)
+        do {
+            try extracted.data.write(to: destination, options: .atomic)
+            return destination
+        } catch {
+            return nil
+        }
+    }
+
+    private func fileURL(for key: String, ext: String) -> URL {
+        let digest = SHA256.hash(data: Data(key.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return directory.appendingPathComponent("\(digest).\(ext)")
+    }
+}
+
+enum ExternalSubtitleFormat {
+    struct Payload {
+        let data: Data
+        let fileExtension: String
+    }
+
+    static func hint(forFileURL url: URL) -> String? {
+        let ext = url.pathExtension.lowercased()
+        guard ["srt", "vtt", "ass", "ssa"].contains(ext) else { return nil }
+        return ext
+    }
+
+    static func payload(
+        data: Data,
+        response: HTTPURLResponse,
+        sourceURL: URL
+    ) -> Payload? {
+        let ext = inferredExtension(data: data, response: response, sourceURL: sourceURL)
+        guard looksLikeSubtitleText(data) || ["srt", "vtt", "ass", "ssa"].contains(ext) else {
+            return nil
+        }
+        return Payload(data: data, fileExtension: ext)
+    }
+
+    static func inferredExtension(
+        data: Data,
+        response: HTTPURLResponse,
+        sourceURL: URL
+    ) -> String {
+        if let fromDisposition = extensionFromContentDisposition(
+            response.value(forHTTPHeaderField: "Content-Disposition")
+        ) {
+            return fromDisposition
+        }
+        if let fromType = extensionFromContentType(
+            response.value(forHTTPHeaderField: "Content-Type")
+        ) {
+            return fromType
+        }
+        let pathExt = sourceURL.pathExtension.lowercased()
+        if ["srt", "vtt", "ass", "ssa"].contains(pathExt) {
+            return pathExt
+        }
+        return sniffExtension(from: data) ?? "srt"
+    }
+
+    static func extensionFromContentDisposition(_ header: String?) -> String? {
+        guard let header else { return nil }
+        let patterns = [
+            #"filename\*=(?:UTF-8''|utf-8'')([^;]+)"#,
+            #"filename=\"([^\"]+)\""#,
+            #"filename=([^;]+)"#
+        ]
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+                  let match = regex.firstMatch(
+                      in: header,
+                      range: NSRange(header.startIndex..., in: header)
+                  ),
+                  let range = Range(match.range(at: 1), in: header) else {
+                continue
+            }
+            var name = String(header[range]).trimmingCharacters(in: .whitespacesAndNewlines)
+            name = name.removingPercentEncoding ?? name
+            let ext = URL(fileURLWithPath: name).pathExtension.lowercased()
+            if ["srt", "vtt", "ass", "ssa"].contains(ext) { return ext }
+        }
+        return nil
+    }
+
+    static func extensionFromContentType(_ header: String?) -> String? {
+        guard let header else { return nil }
+        let lower = header.lowercased()
+        if lower.contains("webvtt") || lower.contains("text/vtt") { return "vtt" }
+        if lower.contains("ass") || lower.contains("ssa") { return "ass" }
+        if lower.contains("subrip") || lower.contains("x-subrip") || lower.contains("srt") {
+            return "srt"
+        }
+        return nil
+    }
+
+    static func sniffExtension(from data: Data) -> String? {
+        guard let prefix = String(data: data.prefix(256), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() else { return nil }
+        if prefix.hasPrefix("webvtt") { return "vtt" }
+        if prefix.contains("[script info]") || prefix.contains("dialogue:") { return "ass" }
+        if prefix.contains("-->") { return "srt" }
+        return nil
+    }
+
+    static func looksLikeSubtitleText(_ data: Data) -> Bool {
+        sniffExtension(from: data) != nil
+    }
+
+    static func isZip(_ data: Data) -> Bool {
+        data.count >= 4 && data[0] == 0x50 && data[1] == 0x4b && data[2] == 0x03 && data[3] == 0x04
+    }
+}

--- a/tvosApp/NuvioTV/Sources/Core/Player/MPVPlaybackController.swift
+++ b/tvosApp/NuvioTV/Sources/Core/Player/MPVPlaybackController.swift
@@ -1133,7 +1133,7 @@ final class MPVPlayerViewController: UIViewController, PlaybackEngineControlling
     func addSubtitle(_ subtitle: NuvioSubtitle, select: Bool) {
         guard mpv != nil else { return }
         command("sub-add", args: [
-            subtitle.url,
+            subtitle.engineURL,
             select ? "select" : "auto",
             subtitle.label ?? "",
             subtitle.language

--- a/tvosApp/NuvioTV/Sources/Models/CatalogModels.swift
+++ b/tvosApp/NuvioTV/Sources/Models/CatalogModels.swift
@@ -700,6 +700,25 @@ struct NuvioSubtitle: Identifiable, Codable, Equatable {
     /// Where the subtitle came from ("OpenSubtitles v3", stream add-on name);
     /// shown as the badge in the player's subtitle picker.
     var source: String? = nil
+    /// Local file URL engines should load. Kept separate from `url` so the
+    /// player Settings list can keep matching the original add-on identity.
+    var playbackURL: String? = nil
+    /// File-extension hint for extensionless Stremio download URLs ("srt", …).
+    var formatHint: String? = nil
+
+    /// URL handed to MPV / Aether for decoding.
+    var engineURL: String { playbackURL ?? url }
+
+    private enum CodingKeys: String, CodingKey {
+        case url, language, label, source
+    }
+
+    static func == (lhs: NuvioSubtitle, rhs: NuvioSubtitle) -> Bool {
+        lhs.url == rhs.url
+            && lhs.language == rhs.language
+            && lhs.label == rhs.label
+            && lhs.source == rhs.source
+    }
 }
 
 struct NuvioStream: Identifiable, Codable {

--- a/tvosApp/NuvioTV/Sources/ViewModels/PlayerViewModel.swift
+++ b/tvosApp/NuvioTV/Sources/ViewModels/PlayerViewModel.swift
@@ -232,6 +232,9 @@ class PlayerViewModel: ObservableObject {
     private var pendingExternalSubtitles: [NuvioSubtitle] = []
     private var didAddExternalSubtitles = false
     private var addedExternalSubtitleURLs: Set<String> = []
+    /// Maps an engine-local path (`file:///…` or absolute path) back to the
+    /// original add-on subtitle URL so the Settings panel can keep matching.
+    private var externalSubtitleIdentityByEngineURL: [String: String] = [:]
     private var pendingSelectedExternalSubtitleURL: String?
     private var subtitleFetchTask: Task<Void, Never>?
     private var activeTrackSelectionKey: String?
@@ -586,7 +589,10 @@ class PlayerViewModel: ObservableObject {
             audioURL: nil,
             resumePositionSeconds: pendingResumeSeconds,
             httpHeaders: httpHeaders,
-            externalSubtitles: pendingExternalSubtitles,
+            // Remote add-on sidecars are downloaded then `sub-add`ed after the
+            // engine is ready. Passing them here would attach stream auth headers
+            // (MPV http-header-fields / Aether LoadOptions) and break OpenSubtitles.
+            externalSubtitles: [],
             preferredAudioLanguages: preferredAudioLanguageCodes(),
             preferredSubtitleLanguages: preferredSubtitleLanguageCodes(),
             matchContentEnabled: matchContent,
@@ -609,12 +615,12 @@ class PlayerViewModel: ObservableObject {
             request,
             requiresMPVAudioControls: audioDelayMs != 0 || audioAmplificationDb > 0
         )
-        // The coordinator owns initial seek and subtitle registration on both
-        // backends; later progressive subtitle results still flow through the
-        // incremental path below.
+        // The coordinator owns initial seek on both backends; external add-on
+        // subtitles are prepared and attached through the incremental path below.
         didApplyResume = (request.resumePositionSeconds ?? 0) > 5
-        didAddExternalSubtitles = true
-        addedExternalSubtitleURLs.formUnion(request.externalSubtitles.map(\.url))
+        didAddExternalSubtitles = pendingExternalSubtitles.isEmpty
+        addedExternalSubtitleURLs = []
+        externalSubtitleIdentityByEngineURL = [:]
         activeEngineKind = sessionCoordinator.activeBackend
         hdrModeToast = sessionCoordinator.statusToast
         if let toast = sessionCoordinator.statusToast {
@@ -750,6 +756,7 @@ class PlayerViewModel: ObservableObject {
         )
         self.didAddExternalSubtitles = pendingExternalSubtitles.isEmpty
         self.addedExternalSubtitleURLs = []
+        self.externalSubtitleIdentityByEngineURL = [:]
         self.pendingSelectedExternalSubtitleURL = nil
         self.isAISubtitleTranslationManuallyEnabled = false
         if !preserveSessionPreferences {
@@ -1779,10 +1786,14 @@ class PlayerViewModel: ObservableObject {
         if audioTracks != latestAudioTracks { audioTracks = latestAudioTracks }
 
         var subs = c.subtitleTracks.map {
-            SubtitleTrack(id: "\($0.id)", name: $0.title,
-                          language: $0.lang, isSelected: $0.selected,
-                          externalFilename: $0.externalFilename,
-                          isNativelyRenderedSubtitle: $0.isNativelyRenderedSubtitle)
+            SubtitleTrack(
+                id: "\($0.id)",
+                name: $0.title,
+                language: $0.lang,
+                isSelected: $0.selected,
+                externalFilename: identityURL(forEngineFilename: $0.externalFilename),
+                isNativelyRenderedSubtitle: $0.isNativelyRenderedSubtitle
+            )
         }
         let anySelected = subs.contains { $0.isSelected }
         subs.insert(SubtitleTrack(id: "off", name: "Off", language: "",
@@ -2637,14 +2648,46 @@ class PlayerViewModel: ObservableObject {
             let selected = subtitlesToAdd.remove(at: index)
             subtitlesToAdd.append(selected)
         }
-        subtitlesToAdd.forEach { subtitle in
-            engine.addSubtitle(
-                subtitle,
-                select: subtitle.url == pendingSelectedExternalSubtitleURL
-            )
-            addedExternalSubtitleURLs.insert(subtitle.url)
+        guard !subtitlesToAdd.isEmpty else {
+            didAddExternalSubtitles = true
+            return
         }
+        // Mark in-flight so poll ticks do not start a second download wave.
         didAddExternalSubtitles = true
+        let selectedURL = pendingSelectedExternalSubtitleURL
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            for subtitle in subtitlesToAdd {
+                let prepared = await ExternalSubtitleFileCache.shared.prepare(subtitle)
+                self.rememberEngineIdentity(for: prepared)
+                self.engine.addSubtitle(
+                    prepared,
+                    select: prepared.url == selectedURL
+                )
+                self.addedExternalSubtitleURLs.insert(prepared.url)
+            }
+        }
+    }
+
+    private func rememberEngineIdentity(for subtitle: NuvioSubtitle) {
+        guard let playbackURL = subtitle.playbackURL, !playbackURL.isEmpty else { return }
+        externalSubtitleIdentityByEngineURL[playbackURL] = subtitle.url
+        if let fileURL = URL(string: playbackURL), fileURL.isFileURL {
+            externalSubtitleIdentityByEngineURL[fileURL.path] = subtitle.url
+            externalSubtitleIdentityByEngineURL[fileURL.absoluteString] = subtitle.url
+        }
+    }
+
+    private func identityURL(forEngineFilename filename: String) -> String {
+        guard !filename.isEmpty else { return filename }
+        if let identity = externalSubtitleIdentityByEngineURL[filename] {
+            return identity
+        }
+        if let fileURL = URL(string: filename), fileURL.isFileURL,
+           let identity = externalSubtitleIdentityByEngineURL[fileURL.path] {
+            return identity
+        }
+        return filename
     }
 
     private func applySavedTrackSelectionsIfNeeded() {

--- a/tvosApp/NuvioTVTests/ExternalSubtitleFileCacheTests.swift
+++ b/tvosApp/NuvioTVTests/ExternalSubtitleFileCacheTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import NuvioTV
+
+final class ExternalSubtitleFileCacheTests: XCTestCase {
+    func testInfersExtensionFromContentDisposition() {
+        let ext = ExternalSubtitleFormat.extensionFromContentDisposition(
+            "attachment; filename=\"movie.en.srt\""
+        )
+        XCTAssertEqual(ext, "srt")
+    }
+
+    func testInfersExtensionFromContentType() {
+        XCTAssertEqual(
+            ExternalSubtitleFormat.extensionFromContentType("application/x-subrip; charset=utf-8"),
+            "srt"
+        )
+        XCTAssertEqual(
+            ExternalSubtitleFormat.extensionFromContentType("text/vtt"),
+            "vtt"
+        )
+    }
+
+    func testSniffsSRTWithoutExtension() {
+        let data = Data("1\n00:00:01,000 --> 00:00:02,000\nHello\n".utf8)
+        XCTAssertEqual(ExternalSubtitleFormat.sniffExtension(from: data), "srt")
+        XCTAssertTrue(ExternalSubtitleFormat.looksLikeSubtitleText(data))
+    }
+
+    func testDetectsZipMagic() {
+        XCTAssertTrue(ExternalSubtitleFormat.isZip(Data([0x50, 0x4b, 0x03, 0x04, 0x00])))
+        XCTAssertFalse(ExternalSubtitleFormat.isZip(Data("1\n00:00:01,000 --> 00:00:02,000\n".utf8)))
+    }
+
+    func testEngineURLPrefersPlaybackURL() {
+        var subtitle = NuvioSubtitle(
+            url: "https://subs.example/file/1",
+            language: "en",
+            label: "English",
+            source: "OpenSubtitles"
+        )
+        XCTAssertEqual(subtitle.engineURL, subtitle.url)
+        subtitle.playbackURL = "file:///tmp/en.srt"
+        subtitle.formatHint = "srt"
+        XCTAssertEqual(subtitle.engineURL, "file:///tmp/en.srt")
+        XCTAssertEqual(subtitle.url, "https://subs.example/file/1")
+    }
+
+    func testPayloadUsesContentTypeWhenPathHasNoExtension() throws {
+        let data = Data("1\n00:00:01,000 --> 00:00:02,000\nHello\n".utf8)
+        let url = try XCTUnwrap(URL(string: "https://subs5.strem.io/en/download/file/36919"))
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: [
+                "Content-Type": "application/x-subrip; charset=utf-8",
+                "Content-Disposition": "attachment; filename=\"movie.srt\""
+            ]
+        )!
+        let payload = try XCTUnwrap(
+            ExternalSubtitleFormat.payload(data: data, response: response, sourceURL: url)
+        )
+        XCTAssertEqual(payload.fileExtension, "srt")
+    }
+}


### PR DESCRIPTION
## Summary
- Addon subtitle files appeared in the player list but did not render because remote OpenSubtitles/subDL URLs were loaded through the stream’s MPV/Aether HTTP headers and often had no file extension.
- Download selected/preloaded addon subtitles to a local cache with a normal User-Agent, infer `.srt`/`.vtt`/`.ass` from Content-Disposition / Content-Type / payload sniffing, and attach `file://` paths after the engine is ready.
- Keep the original remote URL as the Settings-panel identity so selection/matching still works.

Fixes #57

## Test plan
- [x] Play a title with OpenSubtitles v3 / Pro / subDL installed
- [x] Confirm addon subtitles appear in the player subtitle list
- [x] Select an addon subtitle and confirm cues render within a few seconds (not minutes / never)
- [x] Confirm embedded source subtitles still work
- [ ] Run `ExternalSubtitleFileCacheTests`