### PR TITLE
Port tvOS fixes from fork main

### DIFF
--- a/tvosApp/NuvioTV/Sources/Core/Addons/AddonTransportUrls.swift
+++ b/tvosApp/NuvioTV/Sources/Core/Addons/AddonTransportUrls.swift
@@ -59,13 +59,22 @@ public enum AddonTransportUrls {
         extraPathSegment: String? = nil
     ) -> URL? {
         let base = baseUrl(from: manifestURL)
+        let canonicalType: String
+        switch type.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "series", "tv", "show", "tvshow", "tv_series", "shows":
+            canonicalType = "series"
+        case "movie", "movies", "film", "films":
+            canonicalType = "movie"
+        default:
+            canonicalType = type
+        }
         let encodedId = encodePathSegment(id)
         let q = query(from: manifestURL)
         let path: String
         if let extra = extraPathSegment, !extra.isEmpty {
-            path = "\(base)/\(resource)/\(type)/\(encodedId)/\(extra).json\(q)"
+            path = "\(base)/\(resource)/\(canonicalType)/\(encodedId)/\(extra).json\(q)"
         } else {
-            path = "\(base)/\(resource)/\(type)/\(encodedId).json\(q)"
+            path = "\(base)/\(resource)/\(canonicalType)/\(encodedId).json\(q)"
         }
         return URL(string: path)
     }

--- a/tvosApp/NuvioTV/Sources/Models/CatalogModels.swift
+++ b/tvosApp/NuvioTV/Sources/Models/CatalogModels.swift
@@ -417,6 +417,22 @@ struct NuvioVideo: Identifiable, Codable, Hashable {
     let rating: String?
 }
 
+/// Canonical stream lookup identity for an episode. Episode guides can be
+/// enriched by TMDB (and therefore carry a `tmdb:` id) even when the stream
+/// add-ons use the series' IMDb id. Keep manual playback and autoplay on the
+/// same lookup identity.
+enum EpisodeStreamIdentity {
+    static func canonicalID(for episode: NuvioVideo, seriesStreamID: String?) -> String {
+        if episode.id.hasPrefix("tt") {
+            return episode.id
+        }
+        if let seriesStreamID, seriesStreamID.hasPrefix("tt") {
+            return "\(seriesStreamID):\(episode.season):\(episode.episode)"
+        }
+        return episode.id
+    }
+}
+
 enum EpisodeReleasePolicy {
     static let showUnairedNextUpKey = "nuvio.tv.settings.layout.showUnairedNextUp"
     static let upcomingNextSeasonWindowDays = 7

--- a/tvosApp/NuvioTV/Sources/Models/PlayerModels.swift
+++ b/tvosApp/NuvioTV/Sources/Models/PlayerModels.swift
@@ -355,6 +355,7 @@ struct ExternalPlaybackCallback: Equatable {
     let isError: Bool
     let progress: Double?
     let position: Double?
+    let duration: Double?
 
     static func parse(_ url: URL) -> ExternalPlaybackCallback? {
         guard url.scheme?.lowercased() == "nuvio-tv",
@@ -380,8 +381,23 @@ struct ExternalPlaybackCallback: Equatable {
             id: id,
             isError: isError,
             progress: progress,
-            position: number("position")
+            position: number("position"),
+            duration: number("duration")
         )
+    }
+
+    /// Infuse's current `/play` callback reports an exit position in seconds;
+    /// older builds reported a normalized `progress` fraction. Prefer the
+    /// callback's duration when supplied, then fall back to the runtime Nuvio
+    /// stored with the handoff session.
+    func completionProgress(using fallbackDuration: Double?) -> Double? {
+        if let progress { return progress }
+        guard let position, position.isFinite, position >= 0 else { return nil }
+        let duration = duration ?? fallbackDuration
+        guard let duration, duration.isFinite, duration > 0 else { return nil }
+        let fraction = position / duration
+        guard fraction.isFinite, (0...1).contains(fraction) else { return nil }
+        return fraction
     }
 }
 

--- a/tvosApp/NuvioTV/Sources/NuvioTVApp.swift
+++ b/tvosApp/NuvioTV/Sources/NuvioTVApp.swift
@@ -1122,7 +1122,11 @@ struct ContentView: View {
         continueWatchingPlaybackTask = Task {
             let prepared: PreparedNextStream?
             if let episode = context.current {
-                prepared = await Self.resolveNextEpisodeStream(episode: episode, profileId: profileId)
+                prepared = await Self.resolveNextEpisodeStream(
+                    episode: episode,
+                    seriesStreamID: item.meta.streamId,
+                    profileId: profileId
+                )
             } else if item.meta.isSeries, let numbers = item.episodeNumbers {
                 prepared = await Self.resolveStream(
                     contentId: "\(item.meta.id):\(numbers.season):\(numbers.episode)",
@@ -1822,9 +1826,17 @@ struct ContentView: View {
     /// seamless auto-advance: fetches the episode's streams (concurrently) and
     /// applies the same smart selection the details screen uses. Returns nil when
     /// nothing real is available, so the player falls back to a normal end.
-    private static func resolveNextEpisodeStream(episode: NuvioVideo, profileId: String?) async -> PreparedNextStream? {
-        await resolveStream(
-            contentId: episode.id,
+    private static func resolveNextEpisodeStream(
+        episode: NuvioVideo,
+        seriesStreamID: String? = nil,
+        profileId: String?
+    ) async -> PreparedNextStream? {
+        let contentId = EpisodeStreamIdentity.canonicalID(
+            for: episode,
+            seriesStreamID: seriesStreamID
+        )
+        return await resolveStream(
+            contentId: contentId,
             type: "series",
             subtitleLine: "S\(episode.season) · E\(episode.episode) · \(episode.title)",
             profileId: profileId
@@ -2111,7 +2123,11 @@ struct ContentView: View {
             autoPlayNextEnabled: autoPlayNext,
             autoPlayNextCountdownSeconds: autoPlayNextCountdown,
             resolveNextStream: (isTrailer || !meta.isSeries) ? nil : { episode in
-                await Self.resolveNextEpisodeStream(episode: episode, profileId: profileViewModel.activeProfile?.id)
+                await Self.resolveNextEpisodeStream(
+                    episode: episode,
+                    seriesStreamID: meta.streamId,
+                    profileId: profileViewModel.activeProfile?.id
+                )
             },
             reloadCurrentStream: isTrailer ? nil : { excludedURLs in
                 let profileId = profileViewModel.activeProfile?.id

--- a/tvosApp/NuvioTV/Sources/NuvioTVApp.swift
+++ b/tvosApp/NuvioTV/Sources/NuvioTVApp.swift
@@ -30,10 +30,14 @@ struct NuvioTVApp: App {
     }
 }
 
-/// Temporary Home performance tracing. Enabled by default in DEBUG so console
-/// output shows main-thread stalls, or via `-TVHomeDebugTrace` argument.
+/// Temporary Home performance tracing. Keep the hot-path instrumentation out of
+/// release builds: Home renders and focus changes call into this type frequently.
 enum TVHomeDebugTrace {
-    static var enabled = true
+    #if DEBUG
+    static let enabled = true
+    #else
+    static let enabled = false
+    #endif
     private static let logger = Logger(
         subsystem: "com.pyksel.nuviotvos",
         category: "TVTrace"
@@ -831,11 +835,9 @@ struct ContentView: View {
         // session still makes retries/idempotent duplicate callbacks harmless.
         guard !callback.isError else { return }
 
-        let duration = session.duration.flatMap { $0.isFinite && $0 > 0 ? $0 : nil }
-        let progress = callback.progress ?? callback.position.flatMap { position in
-            guard let duration, position.isFinite, position >= 0 else { return nil }
-            return position / duration
-        }
+        let duration = callback.duration.flatMap { $0.isFinite && $0 > 0 ? $0 : nil }
+            ?? session.duration.flatMap { $0.isFinite && $0 > 0 ? $0 : nil }
+        let progress = callback.completionProgress(using: duration)
         guard let progress, progress.isFinite, (0...1).contains(progress) else { return }
 
         let isEpisode = session.meta.isSeries && session.season != nil && session.episode != nil

--- a/tvosApp/NuvioTV/Sources/UI/Details/DetailsScreen.swift
+++ b/tvosApp/NuvioTV/Sources/UI/Details/DetailsScreen.swift
@@ -329,13 +329,7 @@ struct DetailsScreen: View {
     }
 
     private func canonicalEpisodeStreamId(for video: NuvioVideo, meta: NuvioMeta?) -> String {
-        if video.id.hasPrefix("tt") {
-            return video.id
-        }
-        if let metaStreamId = meta?.streamId, metaStreamId.hasPrefix("tt") {
-            return "\(metaStreamId):\(video.season):\(video.episode)"
-        }
-        return video.id
+        EpisodeStreamIdentity.canonicalID(for: video, seriesStreamID: meta?.streamId)
     }
 
     private func startStreamFlow(streamId: String, type: String, reload: Bool, forceManualPicker: Bool = false) {

--- a/tvosApp/NuvioTVTests/DetailsViewModelTests.swift
+++ b/tvosApp/NuvioTVTests/DetailsViewModelTests.swift
@@ -355,6 +355,24 @@ final class DetailsViewModelTests: XCTestCase {
         XCTAssertEqual(merged?.first(where: { $0.season == 4 })?.title, "S4E1 TMDB Title")
     }
 
+    func testEpisodeStreamIdentityUsesSeriesIMDbIDForEnrichedEpisodes() {
+        let episode = NuvioVideo(
+            id: "tmdb:12345:2:7",
+            title: "Episode 7",
+            season: 2,
+            episode: 7,
+            thumbnail: nil,
+            overview: nil,
+            released: nil,
+            rating: nil
+        )
+
+        XCTAssertEqual(
+            EpisodeStreamIdentity.canonicalID(for: episode, seriesStreamID: "tt7654321"),
+            "tt7654321:2:7"
+        )
+    }
+
     func testCatalogPreviewsDoNotCountAsFullCachedMetadata() {
         let repo = CinemetaCatalogRepository()
         let testId = "tt_test_series_preview"

--- a/tvosApp/NuvioTVTests/StreamQualityTagsTests.swift
+++ b/tvosApp/NuvioTVTests/StreamQualityTagsTests.swift
@@ -342,6 +342,18 @@ final class StreamQualityTagsTests: XCTestCase {
         XCTAssertEqual(WatchProgressLedger.completionFraction, 0.90)
     }
 
+    func testInfusePositionCallbackCanDetermineCompletionFromSessionRuntime() {
+        let callback = ExternalPlaybackCallback.parse(
+            URL(string: "nuvio-tv://external-playback/ABC-123?position=540")!
+        )
+
+        XCTAssertEqual(
+            callback?.completionProgress(using: 600) ?? -1,
+            0.9,
+            accuracy: 0.0001
+        )
+    }
+
     func testExternalPlaybackCallbackRejectsProgressOutsideDocumentedFractionBounds() {
         XCTAssertNil(ExternalPlaybackCallback.parse(
             URL(string: "nuvio-tv://external-playback/id?progress=-0.01")!
@@ -938,4 +950,3 @@ final class StreamQualityTagsTests: XCTestCase {
         XCTAssertFalse(matchedNames.contains("SDR"), "SDR badge must be suppressed when HDR/DV is present")
     }
 }
-

--- a/tvosApp/NuvioTVTests/StreamsDiscoveryTests.swift
+++ b/tvosApp/NuvioTVTests/StreamsDiscoveryTests.swift
@@ -560,4 +560,27 @@ final class StreamsDiscoveryTests: XCTestCase {
         // Non-matching id prefix should fail
         XCTAssertFalse(manifest.supportsResource("stream", type: "series", id: "kitsu:1234"))
     }
+
+    func testAddonTransportUrlsCanonicalizesStremioTypeAliases() {
+        let manifestURL = URL(string: "https://example.com/manifest.json")!
+
+        XCTAssertEqual(
+            AddonTransportUrls.buildResourceURL(
+                manifestURL: manifestURL,
+                resource: "stream",
+                type: "tv",
+                id: "tt1234567:1:1"
+            )?.absoluteString,
+            "https://example.com/stream/series/tt1234567%3A1%3A1.json"
+        )
+        XCTAssertEqual(
+            AddonTransportUrls.buildResourceURL(
+                manifestURL: manifestURL,
+                resource: "stream",
+                type: "movies",
+                id: "tt1234567"
+            )?.absoluteString,
+            "https://example.com/stream/movie/tt1234567.json"
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Ports the two fork-main fixes to the upstream tvOS branch:

- Add-on resource type aliases are canonicalized, Infuse playback callbacks derive completion progress safely, and release tracing stays out of release builds.
- Manual episode playback and next-episode autoplay now share the same canonical stream identity when catalog metadata is enriched.
- Includes the regression tests from both source commits.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

These changes address playback handoff completion reporting and next-episode stream lookup failures, plus incorrect add-on type aliases that prevent valid stream requests.

## Issue or approval

Related to the Infuse handoff regression in #34 and the next-episode autoplay regression in #16.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

No UI redesign, dependency changes, architecture changes, or unrelated fork-scaffold changes are included. The PR is limited to the two requested fork commits and their regression tests.

## Testing

- `git diff --check origin/main...HEAD` passed.
- `xcodebuild test` was attempted with the `NuvioTVTests` target, but dependency resolution could not complete because the upstream `MPVKit` submodule URL (`https://github.com/bobsupra/MPVKit.git`) currently returns `Repository not found`.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Related to #34 and #16.