### PR TITLE
Don't spinner when connection unstable but buffer is full

### DIFF
--- a/tvosApp/NuvioTV/Sources/Core/Player/AetherPlaybackController.swift
+++ b/tvosApp/NuvioTV/Sources/Core/Player/AetherPlaybackController.swift
@@ -1953,10 +1953,12 @@ final class AetherPlaybackController: UIViewController, PlaybackEngineControllin
             }
             .store(in: &cancellables)
 
-        engine.$playbackPhase
+        // `.stalled` outranks `.rebuffering` in the engine's phase fold, so the buffer axis
+        // has to be observed alongside it to tell a masked reconnect from a frozen picture.
+        Publishers.CombineLatest(engine.$playbackPhase, engine.$isBuffering)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] phase in
-                self?.applyPhase(phase)
+            .sink { [weak self] phase, isBuffering in
+                self?.applyPhase(phase, engineIsBuffering: isBuffering)
             }
             .store(in: &cancellables)
 
@@ -2040,7 +2042,7 @@ final class AetherPlaybackController: UIViewController, PlaybackEngineControllin
             .store(in: &cancellables)
     }
 
-    private func applyPhase(_ phase: PlaybackPhase) {
+    private func applyPhase(_ phase: PlaybackPhase, engineIsBuffering: Bool) {
         switch phase {
         case .idle:
             isPlayerLoading = false
@@ -2063,7 +2065,8 @@ final class AetherPlaybackController: UIViewController, PlaybackEngineControllin
             isPlayerLoading = true
             // Keep last isPlayerPlaying so UI does not flicker pause icons.
         case .stalled:
-            isPlayerLoading = true
+            // A reader reconnect over still-buffered media leaves the picture rolling.
+            isPlayerLoading = !isPlayerPlaying || engineIsBuffering
         case .ended:
             isPlayerLoading = false
             isPlayerPlaying = false
@@ -2519,7 +2522,7 @@ final class AetherPlaybackController: UIViewController, PlaybackEngineControllin
         refreshClock()
         mapAudioTracks(engine.audioTracks)
         mapSubtitleTracks(engine.subtitleTracks)
-        applyPhase(engine.playbackPhase)
+        applyPhase(engine.playbackPhase, engineIsBuffering: engine.isBuffering)
         #if os(tvOS) || os(iOS)
         configureRemoteCommandsIfNeeded()
         #endif


### PR DESCRIPTION
## Summary

Fix the spinner so if there's remaining playback buffer it doesn't spin on connection instability.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On systems using remote playback providers (debrid, webdav, etc), it was not uncommon to encounter connection hiccups. The existing code shows a spinner on any connection issues, even if there's still a (potentially very large with "Max" buffer size set) remaining buffer and playback is uninterrupted.

## Issue or approval

This is a pretty small but impactful issue (I was experiencing it on every playback multiple times, even though playback kept going with the spinner overlaid). It was easier to make and test a fix for it than write an issue for it (issue would've been too generic without identifying thee problem first).

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Confirming this is limited in scope to the bugfix.

## Testing

Tested on AppleTV 4k w/ AIOStreams connection to debrid providers. Tested w/ the simulator to capture the proof video.

## Screenshots / Video (UI changes only)

Coming up with an example of this in a way I could capture was moderately difficult. Best I could get was injecting the `.reconnect` signal via the simulator to show the resulting behavior of a flaky source that triggers that (I couldn't get the native path with a flaky proxy to the file to play and show the full problem).


https://github.com/user-attachments/assets/fd16d34b-0b55-4554-9d92-7157edd99d22

## Breaking changes

None.

## Linked issues

Reason for no linked issue was above in the Issue or Approval section.
